### PR TITLE
Move QDigest to "test" scoped dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
             <groupId>com.clearspring.analytics</groupId>
             <artifactId>stream</artifactId>
             <version>2.5.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Is it possible to down scope the QDigest dependency to test only?  clearspring transitively depends on it.unimi.dsi:fastutil which is over 16 megabytes and is fattening the uber-jars for my projects using t-digest.
