### PR TITLE
Fix unit test

### DIFF
--- a/src/test/java/com/tdunning/math/stats/TDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestTest.java
@@ -279,7 +279,7 @@ public class TDigestTest {
         System.out.printf("# %fus per point\n", (System.nanoTime() - t0) * 1e-3 / 100000);
         System.out.printf("# %d centroids\n", dist.centroidCount());
 
-        assertTrue(String.format("Summary is too large (got %d, wanted < %.1f)", dist.centroidCount(), 11 * sizeGuide), dist.centroidCount() < 10 * sizeGuide);
+        assertTrue(String.format("Summary is too large (got %d, wanted < %.1f)", dist.centroidCount(), 11 * sizeGuide), dist.centroidCount() < 11 * sizeGuide);
         int softErrors = 0;
         for (int i = 0; i < xValues.length; i++) {
             double x = xValues[i];


### PR DESCRIPTION
Got this error sometimes.

```
java.lang.AssertionError: Summary is too large (got 1004, wanted < 1100.0)
    at org.junit.Assert.fail(Assert.java:91)
    at org.junit.Assert.assertTrue(Assert.java:43)
    at com.tdunning.math.stats.TDigestTest.runTest(TDigestTest.java:282)
    at com.tdunning.math.stats.ArrayDigestTest.testSequentialPoints(ArrayDigestTest.java:299)
```
