### PR TITLE
Remove unnecessary calls to GroupTree.headCount.

### DIFF
--- a/src/main/java/com/tdunning/math/stats/ArrayDigest.java
+++ b/src/main/java/com/tdunning/math/stats/ArrayDigest.java
@@ -62,7 +62,7 @@ public class ArrayDigest extends AbstractTDigest {
             Iterable<Index> neighbors = inclusiveTail(start);
             double minDistance = Double.MAX_VALUE;
             int lastNeighbor = 0;
-            int i = headCount(start);
+            int i = 0;
             for (Index neighbor : neighbors) {
                 double z = Math.abs(mean(neighbor) - x);
                 if (z <= minDistance) {
@@ -77,7 +77,7 @@ public class ArrayDigest extends AbstractTDigest {
 
             Index closest = null;
             int sum = headSum(start);
-            i = headCount(start);
+            i = 0;
             double n = 0;
             for (Index neighbor : neighbors) {
                 if (i > lastNeighbor) {

--- a/src/main/java/com/tdunning/math/stats/TreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/TreeDigest.java
@@ -81,7 +81,7 @@ public class TreeDigest extends AbstractTDigest {
             Iterable<Centroid> neighbors = summary.tailSet(start);
             double minDistance = Double.MAX_VALUE;
             int lastNeighbor = 0;
-            int i = summary.headCount(start);
+            int i = 0;
             for (Centroid neighbor : neighbors) {
                 double z = Math.abs(neighbor.mean() - x);
                 if (z <= minDistance) {
@@ -96,7 +96,7 @@ public class TreeDigest extends AbstractTDigest {
 
             Centroid closest = null;
             int sum = summary.headSum(start);
-            i = summary.headCount(start);
+            i = 0;
             double n = 1;
             for (Centroid neighbor : neighbors) {
                 if (i > lastNeighbor) {


### PR DESCRIPTION
`GroupTree.headCount` is currently called twice in `TreeDigest.add`
although its result is not actually used.
