### PR TITLE
Fix pageSize assumptions in Page.split().

### DIFF
--- a/src/main/java/com/tdunning/math/stats/ArrayDigest.java
+++ b/src/main/java/com/tdunning/math/stats/ArrayDigest.java
@@ -822,23 +822,25 @@ public class ArrayDigest extends AbstractTDigest {
         }
 
         private Page split() {
+            assert active == pageSize;
+            final int half = pageSize / 2;
             Page newPage = new Page(pageSize, recordAllData);
-            System.arraycopy(centroids, 16, newPage.centroids, 0, pageSize / 2);
-            System.arraycopy(counts, 16, newPage.counts, 0, pageSize / 2);
+            System.arraycopy(centroids, half, newPage.centroids, 0, pageSize - half);
+            System.arraycopy(counts, half, newPage.counts, 0, pageSize - half);
             if (history != null) {
                 newPage.history = new ArrayList<List<Double>>();
-                newPage.history.addAll(history.subList(pageSize / 2, pageSize));
+                newPage.history.addAll(history.subList(half, pageSize));
 
                 List<List<Double>> tmp = new ArrayList<List<Double>>();
-                tmp.addAll(history.subList(0, pageSize / 2));
+                tmp.addAll(history.subList(0, half));
                 history = tmp;
             }
-            active = 16;
-            newPage.active = 16;
+            active = half;
+            newPage.active = pageSize - half;
 
             newPage.totalCount = totalCount;
             totalCount = 0;
-            for (int i = 0; i < 16; i++) {
+            for (int i = 0; i < half; i++) {
                 totalCount += counts[i];
                 newPage.totalCount -= counts[i];
             }

--- a/src/test/java/com/tdunning/math/stats/ArrayDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/ArrayDigestTest.java
@@ -51,7 +51,9 @@ public class ArrayDigestTest extends TDigestTest {
     private DigestFactory<ArrayDigest> factory = new DigestFactory<ArrayDigest>() {
         @Override
         public ArrayDigest create() {
-            return TDigest.createArrayDigest(100);
+            Random gen = RandomUtils.getRandom();
+            int pageSize = 4 + gen.nextInt(50);
+            return TDigest.createArrayDigest(pageSize, 100);
         }
     };
 
@@ -99,7 +101,7 @@ public class ArrayDigestTest extends TDigestTest {
     // verifies that the data that we add is preserved
     @Test
     public void testAddIterate() {
-        final ArrayDigest ad = new ArrayDigest(32, 100);
+        final ArrayDigest ad = factory.create();
 
         assertEquals("[]", Lists.newArrayList(ad.centroids()).toString());
 
@@ -170,7 +172,7 @@ public class ArrayDigestTest extends TDigestTest {
     @Test
     public void testInternalSums() {
         Random random = new Random();
-        ArrayDigest ad = new ArrayDigest(32, 100);
+        ArrayDigest ad = factory.create();
         for (int i = 0; i < 1000; i++) {
             ad.add(random.nextDouble(), 7);
         }
@@ -220,17 +222,17 @@ public class ArrayDigestTest extends TDigestTest {
 
     @Test
     public void testEmpty() {
-        empty(new ArrayDigest(32, 100));
+        empty(factory.create());
     }
 
     @Test
     public void testSingleValue() {
-        singleValue(new ArrayDigest(32, 100));
+        singleValue(factory.create());
     }
 
     @Test
     public void testFewValues() {
-        fewValues(new ArrayDigest(32, 100));
+        fewValues(factory.create());
     }
 
 
@@ -327,7 +329,7 @@ public class ArrayDigestTest extends TDigestTest {
     @Test
     public void testSerialization() {
         Random gen = RandomUtils.getRandom();
-        TDigest dist = new ArrayDigest(32, 100);
+        TDigest dist = factory.create();
         for (int i = 0; i < 100000; i++) {
             double x = gen.nextDouble();
             dist.add(x);


### PR DESCRIPTION
Page.split() seems to assume 16 is half of the page size, and this makes
ArrayDigest fail to split pages when the page size is < 16 because of
out-of-bound exceptions.
