### PR TITLE
Make TDigest instances able to summarize more than 2B values.

### DIFF
--- a/src/main/java/com/tdunning/math/stats/ArrayDigest.java
+++ b/src/main/java/com/tdunning/math/stats/ArrayDigest.java
@@ -36,7 +36,7 @@ public class ArrayDigest extends AbstractTDigest {
     private final int pageSize;
 
     private List<Page> data = new ArrayList<Page>();
-    private int totalWeight = 0;
+    private long totalWeight = 0;
     private int centroidCount = 0;
     private double compression = 100;
 
@@ -76,7 +76,7 @@ public class ArrayDigest extends AbstractTDigest {
             }
 
             Index closest = null;
-            int sum = headSum(start);
+            long sum = headSum(start);
             i = headCount(start);
             double n = 0;
             for (Index neighbor : neighbors) {
@@ -155,8 +155,8 @@ public class ArrayDigest extends AbstractTDigest {
         }
     }
 
-    public int headSum(Index limit) {
-        int r = 0;
+    public long headSum(Index limit) {
+        long r = 0;
 
         for (int i = 0; limit != null && i < limit.page; i++) {
             r += data.get(i).totalCount;
@@ -225,7 +225,7 @@ public class ArrayDigest extends AbstractTDigest {
     }
 
     @Override
-    public int size() {
+    public long size() {
         return totalWeight;
     }
 

--- a/src/main/java/com/tdunning/math/stats/GroupTree.java
+++ b/src/main/java/com/tdunning/math/stats/GroupTree.java
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
  * ability to sum up the size of elements to the left of a particular group.
  */
 public class GroupTree implements Iterable<Centroid> {
-    private int count;
+    private long count;
     private int size;
     private int depth;
     private Centroid leaf;
@@ -167,7 +167,7 @@ public class GroupTree implements Iterable<Centroid> {
     /**
      * @return the sum of the size() function for all elements strictly before the current element.
      */
-    public int headSum(Centroid base) {
+    public long headSum(Centroid base) {
         if (size == 0) {
             return 0;
         } else if (left == null) {
@@ -394,7 +394,7 @@ public class GroupTree implements Iterable<Centroid> {
         };
     }
 
-    public int sum() {
+    public long sum() {
         return count;
     }
 

--- a/src/main/java/com/tdunning/math/stats/TDigest.java
+++ b/src/main/java/com/tdunning/math/stats/TDigest.java
@@ -98,7 +98,7 @@ public abstract class TDigest {
      *
      * @return The sum of the weights on all centroids.
      */
-    public abstract int size();
+    public abstract long size();
 
     /**
      * Returns the fraction of all points added which are <= x.

--- a/src/main/java/com/tdunning/math/stats/TreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/TreeDigest.java
@@ -47,7 +47,7 @@ public class TreeDigest extends AbstractTDigest {
 
     private double compression = 100;
     private GroupTree summary = new GroupTree();
-    int count = 0; // package private for testing
+    long count = 0; // package private for testing
 
     /**
      * A histogram structure that will record a sketch of a distribution.
@@ -95,7 +95,7 @@ public class TreeDigest extends AbstractTDigest {
             }
 
             Centroid closest = null;
-            int sum = summary.headSum(start);
+            long sum = summary.headSum(start);
             i = summary.headCount(start);
             double n = 1;
             for (Centroid neighbor : neighbors) {
@@ -175,7 +175,7 @@ public class TreeDigest extends AbstractTDigest {
      * @return the number of samples that have been added.
      */
     @Override
-    public int size() {
+    public long size() {
         return count;
     }
 

--- a/src/test/java/com/tdunning/math/stats/ArrayDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/ArrayDigestTest.java
@@ -19,6 +19,7 @@ package com.tdunning.math.stats;
 
 import com.clearspring.analytics.stream.quantile.QDigest;
 import com.google.common.collect.Lists;
+
 import org.apache.mahout.common.RandomUtils;
 import org.apache.mahout.math.jet.random.AbstractContinousDistribution;
 import org.apache.mahout.math.jet.random.Gamma;
@@ -599,5 +600,10 @@ public class ArrayDigestTest extends TDigestTest {
         }
     }
 
+    @Test
+    public void testMoreThan2BValues() {
+        final TDigest digest = factory.create();
+        moreThan2BValues(digest);
+    }
 
 }

--- a/src/test/java/com/tdunning/math/stats/TDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestTest.java
@@ -19,6 +19,7 @@ package com.tdunning.math.stats;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+
 import org.apache.mahout.common.RandomUtils;
 import org.apache.mahout.math.jet.random.AbstractContinousDistribution;
 import org.junit.AfterClass;
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -326,6 +328,26 @@ public class TDigestTest {
     protected void empty(TDigest digest) {
         final double q = RandomUtils.getRandom().nextDouble();
         assertTrue(Double.isNaN(digest.quantile(q)));
+    }
+
+    protected void moreThan2BValues(TDigest digest) {
+        for (int i = 0; i < 10; ++i) {
+            final int count = 1 << 30;
+            digest.add(i, count);
+        }
+        Random gen = RandomUtils.getRandom();
+        for (int i = 0; i < 100; ++i) {
+            final double next = -5 + gen.nextDouble() * 20;
+            digest.add(next);
+        }
+        final double[] quantiles = new double[] {0, 0.1, 0.5, 0.9, 1, gen.nextDouble()};
+        Arrays.sort(quantiles);
+        double prev = Double.NEGATIVE_INFINITY;
+        for (double q : quantiles) {
+            final double v = digest.quantile(q);
+            assertTrue(v >= prev);
+            prev = v;
+        }
     }
 
     public interface DigestFactory<T extends TDigest> {

--- a/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
@@ -463,6 +463,12 @@ public class TreeDigestTest extends TDigestTest {
     }
 
     @Test
+    public void testMoreThan2BValues() {
+        final TDigest digest = new TreeDigest(100);
+        moreThan2BValues(digest);
+    }
+
+    @Test
     public void testExtremeQuantiles() {
         // t-digest shouldn't merge extreme nodes, but let's still test how it would
         // answer to extreme quantiles in that case ('extreme' in the sense that the


### PR DESCRIPTION
Centroid counts remain tracked as integers, but whenever counts of several
centroids need to be summed up, a long is used instead. This should allow
for summarizing datasets of at least several tens of billions of values.

Close #14
