### PR TITLE
Faster tree-based t-digest.

### DIFF
--- a/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
+++ b/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A tree of t-digest centroids.
+ */
+final class AVLGroupTree implements Iterable<Centroid> {
+
+    /* For insertions into the tree */
+    private double centroid;
+    private int count;
+    private List<Double> data;
+
+    private double[] centroids;
+    private int[] counts;
+    private List<Double>[] datas;
+    private int[] aggregatedCounts;
+    private final IntAVLTree tree;
+
+    AVLGroupTree(final boolean record) {
+        tree = new IntAVLTree() {
+
+            @Override
+            protected void resize(int newCapacity) {
+                super.resize(newCapacity);
+                centroids = Arrays.copyOf(centroids, newCapacity);
+                counts = Arrays.copyOf(counts, newCapacity);
+                aggregatedCounts = Arrays.copyOf(aggregatedCounts, newCapacity);
+                if (datas != null) {
+                    datas = Arrays.copyOf(datas, newCapacity);
+                }
+            }
+
+            @Override
+            protected void merge(int node) {
+                // two nodes are never considered equal
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            protected void copy(int node) {
+                centroids[node] = centroid;
+                counts[node] = count;
+                if (datas != null) {
+                    if (data == null) {
+                        if (count != 1) {
+                            throw new IllegalStateException();
+                        }
+                        data = new ArrayList<Double>();
+                        data.add(centroid);
+                    }
+                    datas[node] = data;
+                }
+            }
+
+            @Override
+            protected int compare(int node) {
+                if (centroid < centroids[node]) {
+                    return -1;
+                } else {
+                    // upon equality, the newly added node is considered greater
+                    return 1;
+                }
+            }
+
+            @Override
+            protected void fixAggregates(int node) {
+                super.fixAggregates(node);
+                aggregatedCounts[node] = counts[node] + aggregatedCounts[left(node)] + aggregatedCounts[right(node)];
+            }
+
+        };
+        centroids = new double[tree.capacity()];
+        counts = new int[tree.capacity()];
+        aggregatedCounts = new int[tree.capacity()];
+        if (record) {
+            @SuppressWarnings("unchecked")
+            final List<Double>[] datas = new List[tree.capacity()];
+            this.datas = datas;
+        }
+    }
+
+    /**
+     * Return the number of centroids in the tree.
+     */
+    public int size() {
+        return tree.size();
+    }
+
+    /**
+     * Return the next node.
+     */
+    public int next(int node) {
+        return tree.next(node);
+    }
+
+    /**
+     * Return the mean for the provided node.
+     */
+    public double mean(int node) {
+        return centroids[node];
+    }
+
+    /**
+     * Return the count for the provided node.
+     */
+    public int count(int node) {
+        return counts[node];
+    }
+
+    /**
+     * Return the data for the provided node.
+     */
+    public List<Double> data(int node) {
+        return datas == null ? null : datas[node];
+    }
+
+    /**
+     * Add the provided centroid to the tree.
+     */
+    public void add(double centroid, int count, List<Double> data) {
+        this.centroid = centroid;
+        this.count = count;
+        this.data = data;
+        tree.add();
+    }
+
+    public void add(Centroid centroid) {
+        add(centroid.mean(), centroid.count(), centroid.data());
+    }
+
+    /**
+     * Update values associated with a node, readjusting the tree if necessary.
+     */
+    public void update(int node, double centroid, int count, List<Double> data) {
+        this.centroid = centroid;
+        this.count = count;
+        this.data = data;
+        tree.update(node);
+    }
+
+    /**
+     * Return the last node whose centroid is less than <code>centroid</code>.
+     */
+    public int floor(double centroid) {
+        int floor = IntAVLTree.NIL;
+        for (int node = tree.root(); node != IntAVLTree.NIL; ) {
+            final int cmp = Double.compare(centroid, mean(node));
+            if (cmp <= 0) {
+                node = tree.left(node);
+            } else {
+                floor = node;
+                node = tree.right(node);
+            }
+        }
+        return floor;
+    }
+
+    /**
+     * Return the least node in the tree.
+     */
+    public int first() {
+        return tree.first(tree.root());
+    }
+
+    /**
+     * Compute the number of elements and sum of counts for every entry that
+     * is strictly before <code>node</code>.
+     */
+    public long headSum(int node) {
+        final int left = tree.left(node);
+        long sum = aggregatedCounts[left];
+        for (int n = node, p = tree.parent(node); p != IntAVLTree.NIL; n = p, p = tree.parent(n)) {
+            if (n == tree.right(p)) {
+                final int leftP = tree.left(p);
+                sum += counts[p] + aggregatedCounts[leftP];
+            }
+        }
+        return sum;
+    }
+
+    @Override
+    public Iterator<Centroid> iterator() {
+        return iterator(first());
+    }
+
+    private Iterator<Centroid> iterator(final int startNode) {
+        return new Iterator<Centroid>() {
+
+            int nextNode = startNode;
+
+            @Override
+            public boolean hasNext() {
+                return nextNode != IntAVLTree.NIL;
+            }
+
+            @Override
+            public Centroid next() {
+                final Centroid next = new Centroid(mean(nextNode), count(nextNode));
+                final List<Double> data = data(nextNode);
+                if (data != null) {
+                    for (Double x : data) {
+                        next.insertData(x);
+                    }
+                }
+                nextNode = tree.next(nextNode);
+                return next;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Read-only iterator");
+            }
+
+        };
+    }
+
+    /**
+     * Return the total count of points that have been added to the tree.
+     */
+    public int sum() {
+        return aggregatedCounts[tree.root()];
+    }
+
+    void checkBalance() {
+        tree.checkBalance(tree.root());
+    }
+
+    void checkAggregates() {
+        checkAggregates(tree.root());
+    }
+
+    private void checkAggregates(int node) {
+        assert aggregatedCounts[node] == counts[node] + aggregatedCounts[tree.left(node)] + aggregatedCounts[tree.right(node)];
+        if (node != IntAVLTree.NIL) {
+            checkAggregates(tree.left(node));
+            checkAggregates(tree.right(node));
+        }
+    }
+
+}

--- a/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
@@ -1,0 +1,409 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ *
+ */
+public class AVLTreeDigest extends AbstractTDigest {
+
+    private double compression;
+    private AVLGroupTree summary;
+    long count = 0; // package private for testing
+
+    /**
+     * A histogram structure that will record a sketch of a distribution.
+     *
+     * @param compression How should accuracy be traded for size?  A value of N here will give quantile errors
+     *                    almost always less than 3/N with considerably smaller errors expected for extreme
+     *                    quantiles.  Conversely, you should expect to track about 5 N centroids for this
+     *                    accuracy.
+     */
+    public AVLTreeDigest(double compression) {
+        this.compression = compression;
+        summary = new AVLGroupTree(false);
+    }
+
+    @Override
+    public TDigest recordAllData() {
+        if (summary.size() != 0) {
+            throw new IllegalStateException("Can only ask to record added data on an empty summary");
+        }
+        summary = new AVLGroupTree(true);
+        return super.recordAllData();
+    }
+
+    @Override
+    void add(double x, int w, Centroid base) {
+        if (x != base.mean() || w != base.count()) {
+            throw new IllegalArgumentException();
+        }
+        add(x, w, base.data());
+    }
+
+    @Override
+    public void add(double x, int w) {
+        add(x, w, (List<Double>) null);
+    }
+
+    public void add(double x, int w, List<Double> data) {
+        int start = summary.floor(x);
+        if (start == IntAVLTree.NIL) {
+            start = summary.first();
+        }
+
+        if (start == IntAVLTree.NIL) { // empty summary
+            assert summary.size() == 0;
+            summary.add(x, w, data);
+            count = w;
+        } else {
+            double minDistance = Double.MAX_VALUE;
+            int lastNeighbor = IntAVLTree.NIL;
+            for (int neighbor = start; neighbor != IntAVLTree.NIL; neighbor = summary.next(neighbor)) {
+                double z = Math.abs(summary.mean(neighbor) - x);
+                if (z < minDistance) {
+                    start = neighbor;
+                    minDistance = z;
+                } else if (z > minDistance) {
+                    // as soon as z increases, we have passed the nearest neighbor and can quit
+                    lastNeighbor = neighbor;
+                    break;
+                }
+            }
+
+            int closest = IntAVLTree.NIL;
+            long sum = summary.headSum(start);
+            double n = 0;
+            for (int neighbor = start; neighbor != lastNeighbor; neighbor = summary.next(neighbor)) {
+                assert minDistance == Math.abs(summary.mean(neighbor) - x);
+                double q = count == 1 ? 0.5 : (sum + (summary.count(neighbor) - 1) / 2.0) / (count - 1);
+                double k = 4 * count * q * (1 - q) / compression;
+
+                // this slightly clever selection method improves accuracy with lots of repeated points
+                if (summary.count(neighbor) + w <= k) {
+                    n++;
+                    if (gen.nextDouble() < 1 / n) {
+                        closest = neighbor;
+                    }
+                }
+                sum += summary.count(neighbor);
+            }
+
+            if (closest == IntAVLTree.NIL) {
+                summary.add(x, w, data);
+            } else {
+                // if the nearest point was not unique, then we may not be modifying the first copy
+                // which means that ordering can change
+                double centroid = summary.mean(closest);
+                int count = summary.count(closest);
+                List<Double> d = summary.data(closest);
+                if (d != null) {
+                    if (w == 1) {
+                        d.add(x);
+                    } else {
+                        d.addAll(data);
+                    }
+                }
+                count += w;
+                centroid += w * (x - centroid) / count;
+                summary.update(closest, centroid, count, d);
+            }
+            count += w;
+
+            if (summary.size() > 100 * compression) {
+                // may happen in case of sequential points
+                compress();
+            }
+        }
+    }
+
+    @Override
+    public void compress() {
+        if (summary.size() <= 1) {
+            return;
+        }
+
+        AVLGroupTree centroids = summary;
+        this.summary = new AVLGroupTree(recordAllData);
+
+        final int[] nodes = new int[centroids.size()];
+        nodes[0] = centroids.first();
+        for (int i = 1; i < nodes.length; ++i) {
+            nodes[i] = centroids.next(nodes[i-1]);
+            assert nodes[i] != IntAVLTree.NIL;
+        }
+        assert centroids.next(nodes[nodes.length - 1]) == IntAVLTree.NIL;
+
+        for (int i = centroids.size() - 1; i > 0; --i) {
+            final int other = gen.nextInt(i + 1);
+            final int tmp = nodes[other];
+            nodes[other] = nodes[i];
+            nodes[i] = tmp;
+        }
+
+        for (int node : nodes) {
+            add(centroids.mean(node), centroids.count(node), centroids.data(node));
+        }
+    }
+
+    @Override
+    public void compress(GroupTree other) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the number of samples represented in this histogram.  If you want to know how many
+     * centroids are being used, try centroids().size().
+     *
+     * @return the number of samples that have been added.
+     */
+    @Override
+    public long size() {
+        return count;
+    }
+
+    /**
+     * @param x the value at which the CDF should be evaluated
+     * @return the approximate fraction of all samples that were less than or equal to x.
+     */
+    @Override
+    public double cdf(double x) {
+        AVLGroupTree values = summary;
+        if (values.size() == 0) {
+            return Double.NaN;
+        } else if (values.size() == 1) {
+            return x < values.mean(values.first()) ? 0 : 1;
+        } else {
+            double r = 0;
+
+            // we scan a across the centroids
+            Iterator<Centroid> it = values.iterator();
+            Centroid a = it.next();
+
+            // b is the look-ahead to the next centroid
+            Centroid b = it.next();
+
+            // initially, we set left width equal to right width
+            double left = (b.mean() - a.mean()) / 2;
+            double right = left;
+
+            // scan to next to last element
+            while (it.hasNext()) {
+                if (x < a.mean() + right) {
+                    return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+                }
+                r += a.count();
+
+                a = b;
+                b = it.next();
+
+                left = right;
+                right = (b.mean() - a.mean()) / 2;
+            }
+
+            // for the last element, assume right width is same as left
+            left = right;
+            a = b;
+            if (x < a.mean() + right) {
+                return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+            } else {
+                return 1;
+            }
+        }
+    }
+
+    /**
+     * @param q The quantile desired.  Can be in the range [0,1].
+     * @return The minimum value x such that we think that the proportion of samples is <= x is q.
+     */
+    @Override
+    public double quantile(double q) {
+        if (q < 0 || q > 1) {
+            throw new IllegalArgumentException("q should be in [0,1], got " + q);
+        }
+
+        AVLGroupTree values = summary;
+        if (values.size() == 0) {
+            return Double.NaN;
+        } else if (values.size() == 1) {
+            return values.iterator().next().mean();
+        }
+
+        // if values were stored in a sorted array, index would be the offset we are interested in
+        final double index = q * (count - 1);
+
+        // TODO: since nodes store aggregate counts, it should be possible to compute
+        // quantiles in O(log(centroidCount)) instead of iterating sequentially over all nodes
+
+        double previousMean = Double.NaN, previousIndex = 0;
+        long total = 0;
+        Centroid next;
+        Iterator<? extends Centroid> it = centroids().iterator();
+        while (true) {
+            next = it.next();
+            final double nextIndex = total + (next.count() - 1.0) / 2;
+            if (nextIndex >= index) {
+                if (Double.isNaN(previousMean)) {
+                    // special case 1: the index we are interested in is before the 1st centroid
+                    if (nextIndex == previousIndex) {
+                        return next.mean();
+                    }
+                    // assume values grow linearly between index previousIndex=0 and nextIndex2
+                    Centroid next2 = it.next();
+                    final double nextIndex2 = total + next.count() + (next2.count() - 1.0) / 2;
+                    previousMean = (nextIndex2 * next.mean() - nextIndex * next2.mean()) / (nextIndex2 - nextIndex);
+                }
+                // common case: we found two centroids previous and next so that the desired quantile is
+                // after 'previous' but before 'next'
+                return quantile(previousIndex, index, nextIndex, previousMean, next.mean());
+            } else if (!it.hasNext()) {
+                // special case 2: the index we are interested in is beyond the last centroid
+                // again, assume values grow linearly between index previousIndex and (count - 1)
+                // which is the highest possible index
+                final double nextIndex2 = count - 1;
+                final double nextMean2 = (next.mean() * (nextIndex2 - previousIndex) - previousMean * (nextIndex2 - nextIndex)) / (nextIndex - previousIndex);
+                return quantile(nextIndex, index, nextIndex2, next.mean(), nextMean2);
+            }
+            total += next.count();
+            previousMean = next.mean();
+            previousIndex = nextIndex;
+        }
+    }
+
+    @Override
+    public int centroidCount() {
+        return summary.size();
+    }
+
+    @Override
+    public Iterable<? extends Centroid> centroids() {
+        return summary;
+    }
+
+    @Override
+    public double compression() {
+        return compression;
+    }
+
+    /**
+     * Returns an upper bound on the number bytes that will be required to represent this histogram.
+     */
+    @Override
+    public int byteSize() {
+        return 4 + 8 + 4 + summary.size() * 12;
+    }
+
+    /**
+     * Returns an upper bound on the number of bytes that will be required to represent this histogram in
+     * the tighter representation.
+     */
+    @Override
+    public int smallByteSize() {
+        int bound = byteSize();
+        ByteBuffer buf = ByteBuffer.allocate(bound);
+        asSmallBytes(buf);
+        return buf.position();
+    }
+
+    public final static int VERBOSE_ENCODING = 1;
+    public final static int SMALL_ENCODING = 2;
+
+    /**
+     * Outputs a histogram as bytes using a particularly cheesy encoding.
+     */
+    @Override
+    public void asBytes(ByteBuffer buf) {
+        buf.putInt(VERBOSE_ENCODING);
+        buf.putDouble(compression());
+        buf.putInt(summary.size());
+        for (Centroid centroid : summary) {
+            buf.putDouble(centroid.mean());
+        }
+
+        for (Centroid centroid : summary) {
+            buf.putInt(centroid.count());
+        }
+    }
+
+    @Override
+    public void asSmallBytes(ByteBuffer buf) {
+        buf.putInt(SMALL_ENCODING);
+        buf.putDouble(compression());
+        buf.putInt(summary.size());
+
+        double x = 0;
+        for (Centroid centroid : summary) {
+            double delta = centroid.mean() - x;
+            x = centroid.mean();
+            buf.putFloat((float) delta);
+        }
+
+        for (Centroid centroid : summary) {
+            int n = centroid.count();
+            encode(buf, n);
+        }
+    }
+
+    /**
+     * Reads a histogram from a byte buffer
+     *
+     * @return The new histogram structure
+     */
+    public static AVLTreeDigest fromBytes(ByteBuffer buf) {
+        int encoding = buf.getInt();
+        if (encoding == VERBOSE_ENCODING) {
+            double compression = buf.getDouble();
+            AVLTreeDigest r = new AVLTreeDigest(compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            for (int i = 0; i < n; i++) {
+                means[i] = buf.getDouble();
+            }
+            for (int i = 0; i < n; i++) {
+                r.add(means[i], buf.getInt());
+            }
+            return r;
+        } else if (encoding == SMALL_ENCODING) {
+            double compression = buf.getDouble();
+            AVLTreeDigest r = new AVLTreeDigest(compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            double x = 0;
+            for (int i = 0; i < n; i++) {
+                double delta = buf.getFloat();
+                x += delta;
+                means[i] = x;
+            }
+
+            for (int i = 0; i < n; i++) {
+                int z = decode(buf);
+                r.add(means[i], z);
+            }
+            return r;
+        } else {
+            throw new IllegalStateException("Invalid format for serialized histogram");
+        }
+    }
+
+}

--- a/src/main/java/com/tdunning/math/stats/IntAVLTree.java
+++ b/src/main/java/com/tdunning/math/stats/IntAVLTree.java
@@ -1,0 +1,567 @@
+package com.tdunning.math.stats;
+
+import java.util.Arrays;
+
+
+/**
+ * An AVL-tree structure stored in parallel arrays.
+ * This class only stores the tree structure, so you need to extend it if you
+ * want to add data to the nodes, typically by using arrays and node
+ * identifiers as indices.
+ */
+abstract class IntAVLTree {
+
+    /**
+     * We use <tt>0</tt> instead of <tt>-1</tt> so that left(NIL) works without
+     * condition.
+     */
+    protected static final int NIL = 0;
+
+    /** Grow a size by 1/8. */
+    static int oversize(int size) {
+        return size + (size >>> 3);
+    }
+
+    private final NodeAllocator nodeAllocator;
+    private int root;
+    private int[] parent;
+    private int[] left;
+    private int[] right;
+    private byte[] depth;
+
+    IntAVLTree(int initialCapacity) {
+        nodeAllocator = new NodeAllocator();
+        root = NIL;
+        parent = new int[initialCapacity];
+        left = new int[initialCapacity];
+        right = new int[initialCapacity];
+        depth = new byte[initialCapacity];
+    }
+
+    IntAVLTree() {
+        this(16);
+    }
+
+    /**
+     * Return the current root of the tree.
+     */
+    public int root() {
+        return root;
+    }
+
+    /**
+     * Return the current capacity, which is the number of nodes that this tree
+     * can hold.
+     */
+    public int capacity() {
+        return parent.length;
+    }
+
+    /**
+     * Resize internal storage in order to be able to store data for nodes up to
+     * <code>newCapacity</code> (excluded).
+     */
+    protected void resize(int newCapacity) {
+        parent = Arrays.copyOf(parent, newCapacity);
+        left = Arrays.copyOf(left, newCapacity);
+        right = Arrays.copyOf(right, newCapacity);
+        depth = Arrays.copyOf(depth, newCapacity);
+    }
+
+    /**
+     * Return the size of this tree.
+     */
+    public int size() {
+        return nodeAllocator.size();
+    }
+
+    /**
+     * Return the parent of the provided node.
+     */
+    public int parent(int node) {
+        return parent[node];
+    }
+
+    /**
+     * Return the left child of the provided node.
+     */
+    public int left(int node) {
+        return left[node];
+    }
+
+    /**
+     * Return the right child of the provided node.
+     */
+    public int right(int node) {
+        return right[node];
+    }
+
+    /**
+     * Return the depth nodes that are stored below <code>node</code> including itself.
+     */
+    public int depth(int node) {
+        return depth[node];
+    }
+
+    /**
+     * Return the least node under <code>node</code>.
+     */
+    public int first(int node) {
+        if (node == NIL) {
+            return NIL;
+        }
+        while (true) {
+            final int left = left(node);
+            if (left == NIL) {
+                break;
+            }
+            node = left;
+        }
+        return node;
+    }
+
+    /**
+     * Return the largest node under <code>node</code>.
+     */
+    public int last(int node) {
+        while (true) {
+            final int right = right(node);
+            if (right == NIL) {
+                break;
+            }
+            node = right;
+        }
+        return node;
+    }
+
+    /**
+     * Return the least node that is strictly greater than <code>node</code>.
+     */
+    public final int next(int node) {
+        final int right = right(node);
+        if (right != NIL) {
+            return first(right);
+        } else {
+            int parent = parent(node);
+            while (parent != NIL && node == right(parent)) {
+                node = parent;
+                parent = parent(parent);
+            }
+            return parent;
+        }
+    }
+
+    /**
+     * Return the highest node that is strictly less than <code>node</code>.
+     */
+    public final int prev(int node) {
+        final int left = left(node);
+        if (left != NIL) {
+            return last(left);
+        } else {
+            int parent = parent(node);
+            while (parent != NIL && node == left(parent)) {
+                node = parent;
+                parent = parent(parent);
+            }
+            return parent;
+        }
+    }
+
+    /**
+     * Compare data against data which is stored in <code>node</code>.
+     */
+    protected abstract int compare(int node);
+
+    /**
+     * Compare data into <code>node</code>.
+     */
+    protected abstract void copy(int node);
+
+    /**
+     * Merge data into <code>node</code>.
+     */
+    protected abstract void merge(int node);
+
+
+    /**
+     * Add current data to the tree and return <tt>true</tt> if a new node was added
+     * to the tree or <tt>false</tt> if the node was merged into an existing node.
+     */
+    public boolean add() {
+        if (root == NIL) {
+            root = nodeAllocator.newNode();
+            copy(root);
+            fixAggregates(root);
+            return true;
+        } else {
+            int node = root; assert parent(root) == NIL;
+            int parent = NIL;
+            int cmp;
+            do {
+                cmp = compare(node);
+                if (cmp < 0) {
+                    parent = node;
+                    node = left(node);
+                } else if (cmp > 0) {
+                    parent = node;
+                    node = right(node);
+                } else {
+                    merge(node);
+                    return false;
+                }
+            } while (node != NIL);
+
+            node = nodeAllocator.newNode();
+            if (node >= capacity()) {
+                resize(oversize(node + 1));
+            }
+            copy(node);
+            parent(node, parent);
+            if (cmp < 0) {
+                left(parent, node);
+            } else {
+                assert cmp > 0;
+                right(parent, node);
+            }
+
+            rebalance(node);
+
+            return true;
+        }
+    }
+
+    /**
+     * Find a node in this tree.
+     */
+    public int find() {
+        for (int node = root; node != NIL; ) {
+            final int cmp = compare(node);
+            if (cmp < 0) {
+                node = left(node);
+            } else if (cmp > 0) {
+                node = right(node);
+            } else {
+                return node;
+            }
+        }
+        return NIL;
+    }
+
+    /**
+     * Update <code>node</code> with the current data.
+     */
+    public void update(int node) {
+        final int prev = prev(node);
+        final int next = next(node);
+        if ((prev == NIL || compare(prev) > 0) && (next == NIL || compare(next) < 0)) {
+            // Update can be done in-place
+            copy(node);
+            for (int n = node; n != NIL; n = parent(n)) {
+                fixAggregates(n);
+            }
+        } else {
+            // TODO: it should be possible to find the new node position without
+            // starting from scratch
+            remove(node);
+            add();
+        }
+    }
+
+    /**
+     * Remove the specified node from the tree.
+     */
+    public void remove(int node) {
+        if (node == NIL) {
+            throw new IllegalArgumentException();
+        }
+        if (left(node) != NIL && right(node) != NIL) {
+            // inner node
+            final int next = next(node);
+            assert next != NIL;
+            swap(node, next);
+        }
+        assert left(node) == NIL || right(node) == NIL;
+
+        final int parent = parent(node);
+        int child = left(node);
+        if (child == NIL) {
+            child = right(node);
+        }
+
+        if (child == NIL) {
+            // no children
+            if (node == root) {
+                assert size() == 1 : size();
+                root = NIL;
+            } else {
+                if (node == left(parent)) {
+                    left(parent, NIL);
+                } else {
+                    assert node == right(parent);
+                    right(parent, NIL);
+                }
+            }
+        } else {
+            // one single child
+            if (node == root) {
+                assert size() == 2;
+                root = child;
+            } else if (node == left(parent)) {
+                left(parent, child);
+            } else {
+                assert node == right(parent);
+                right(parent, child);
+            }
+            parent(child, parent);
+        }
+
+        release(node);
+        rebalance(parent);
+    }
+
+    private void release(int node) {
+        left(node, NIL);
+        right(node, NIL);
+        parent(node, NIL);
+        nodeAllocator.release(node);
+    }
+
+    private void swap(int node1, int node2) {
+        final int parent1 = parent(node1);
+        final int parent2 = parent(node2);
+        if (parent1 != NIL) {
+            if (node1 == left(parent1)) {
+                left(parent1, node2);
+            } else {
+                assert node1 == right(parent1);
+                right(parent1, node2);
+            }
+        } else {
+            assert root == node1;
+            root = node2;
+        }
+        if (parent2 != NIL) {
+            if (node2 == left(parent2)) {
+                left(parent2, node1);
+            } else {
+                assert node2 == right(parent2);
+                right(parent2, node1);
+            }
+        } else {
+            assert root == node2;
+            root = node1;
+        }
+        parent(node1, parent2);
+        parent(node2, parent1);
+
+        final int left1 = left(node1);
+        final int left2 = left(node2);
+        left(node1, left2);
+        if (left2 != NIL) {
+            parent(left2, node1);
+        }
+        left(node2, left1);
+        if (left1 != NIL) {
+            parent(left1, node2);
+        }
+
+        final int right1 = right(node1);
+        final int right2 = right(node2);
+        right(node1, right2);
+        if (right2 != NIL) {
+            parent(right2, node1);
+        }
+        right(node2, right1);
+        if (right1 != NIL) {
+            parent(right1, node2);
+        }
+
+        final int depth1 = depth(node1);
+        final int depth2 = depth(node2);
+        depth(node1, depth2);
+        depth(node2, depth1);
+    }
+
+    private int balanceFactor(int node) {
+        return depth(left(node)) - depth(right(node));
+    }
+
+    private void rebalance(int node) {
+        for (int n = node; n != NIL; ) {
+            final int p = parent(n);
+
+            fixAggregates(n);
+
+            switch (balanceFactor(n)) {
+            case -2:
+                final int right = right(n);
+                if (balanceFactor(right) == 1) {
+                    rotateRight(right);
+                }
+                rotateLeft(n);
+                break;
+            case 2:
+                final int left = left(n);
+                if (balanceFactor(left) == -1) {
+                    rotateLeft(left);
+                }
+                rotateRight(n);
+                break;
+            case -1:
+            case 0:
+            case 1:
+                break; // ok
+            default:
+                throw new AssertionError();
+            }
+
+            n = p;
+        }
+    }
+
+    protected void fixAggregates(int node) {
+        depth(node, 1 + Math.max(depth(left(node)), depth(right(node))));
+    }
+
+    /** Rotate left the subtree under <code>n</code> */
+    private void rotateLeft(int n) {
+        final int r = right(n);
+        final int lr = left(r);
+        right(n, lr);
+        if (lr != NIL) {
+            parent(lr, n);
+        }
+        final int p = parent(n);
+        parent(r, p);
+        if (p == NIL) {
+            root = r;
+        } else if (left(p) == n) {
+            left(p, r);
+        } else {
+            assert right(p) == n;
+            right(p, r);
+        }
+        left(r, n);
+        parent(n, r);
+        fixAggregates(n);
+        fixAggregates(parent(n));
+    }
+
+    /** Rotate right the subtree under <code>n</code> */
+    private void rotateRight(int n) {
+        final int l = left(n);
+        final int rl = right(l);
+        left(n, rl);
+        if (rl != NIL) {
+            parent(rl, n);
+        }
+        final int p = parent(n);
+        parent(l, p);
+        if (p == NIL) {
+            root = l;
+        } else if (right(p) == n) {
+            right(p, l);
+        } else {
+            assert left(p) == n;
+            left(p, l);
+        }
+        right(l, n);
+        parent(n, l);
+        fixAggregates(n);
+        fixAggregates(parent(n));
+    }
+
+    private void parent(int node, int parent) {
+        assert node != NIL;
+        this.parent[node] = parent;
+    }
+
+    private void left(int node, int left) {
+        assert node != NIL;
+        this.left[node] = left;
+    }
+
+    private void right(int node, int right) {
+        assert node != NIL;
+        this.right[node] = right;
+    }
+
+    private void depth(int node, int depth) {
+        assert node != NIL;
+        assert depth >= 0 && depth <= Byte.MAX_VALUE;
+        this.depth[node] = (byte) depth;
+    }
+
+    void checkBalance(int node) {
+        if (node == NIL) {
+            assert depth(node) == 0;
+        } else {
+            assert depth(node) == 1 + Math.max(depth(left(node)), depth(right(node)));
+            assert Math.abs(depth(left(node)) - depth(right(node))) <= 1;
+            checkBalance(left(node));
+            checkBalance(right(node));
+        }
+    }
+
+    /**
+     * A stack of int values.
+     */
+    private static class IntStack {
+
+        private int[] stack;
+        private int size;
+
+        IntStack() {
+            stack = new int[0];
+            size = 0;
+        }
+
+        int size() {
+            return size;
+        }
+
+        int pop() {
+            return stack[--size];
+        }
+
+        void push(int v) {
+            if (size >= stack.length) {
+                final int newLength = oversize(size + 1);
+                stack = Arrays.copyOf(stack, newLength);
+            }
+            stack[size++] = v;
+        }
+
+    }
+
+    private static class NodeAllocator {
+
+        private int nextNode;
+        private final IntStack releasedNodes;
+
+        NodeAllocator() {
+            nextNode = NIL + 1;
+            releasedNodes = new IntStack();
+        }
+
+        int newNode() {
+            if (releasedNodes.size() > 0) {
+                return releasedNodes.pop();
+            } else {
+                return nextNode++;
+            }
+        }
+
+        void release(int node) {
+            assert node < nextNode;
+            releasedNodes.push(node);
+        }
+
+        int size() {
+            return nextNode - releasedNodes.size() - 1;
+        }
+
+    }
+
+}

--- a/src/test/java/com/tdunning/math/stats/AVLGroupTreeTest.java
+++ b/src/test/java/com/tdunning/math/stats/AVLGroupTreeTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Random;
+
+import org.apache.mahout.common.RandomUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AVLGroupTreeTest {
+
+    @Before
+    public void setUp() {
+        RandomUtils.useTestSeed();
+    }
+
+    @Test
+    public void testSimpleAdds() {
+        AVLGroupTree x = new AVLGroupTree(false);
+        assertEquals(IntAVLTree.NIL, x.floor(34));
+        assertEquals(IntAVLTree.NIL, x.first());
+        assertEquals(0, x.size());
+        assertEquals(0, x.sum());
+
+        x.add(new Centroid(1));
+        assertEquals(1, x.sum());
+        Centroid centroid = new Centroid(2);
+        centroid.add(3, 1);
+        centroid.add(4, 1);
+        x.add(centroid);
+
+        assertEquals(2, x.size());
+        assertEquals(4, x.sum());
+    }
+
+    @Test
+    public void testBalancing() {
+        AVLGroupTree x = new AVLGroupTree(false);
+        for (int i = 0; i < 101; i++) {
+            x.add(new Centroid(i));
+        }
+
+        assertEquals(101, x.size());
+        assertEquals(101, x.sum());
+
+        x.checkBalance();
+        x.checkAggregates();
+    }
+
+    @Test
+    public void testFloor() {
+        // mostly tested in other tests
+        AVLGroupTree x = new AVLGroupTree(false);
+        for (int i = 0; i < 101; i++) {
+            x.add(new Centroid(i / 2));
+        }
+
+        assertEquals(IntAVLTree.NIL, x.floor(-30));
+
+        for (Centroid centroid : x) {
+            assertEquals(centroid.mean(), x.mean(x.floor(centroid.mean() + 0.1)), 0);
+        }
+    }
+
+    @Test
+    public void testHeadSum() {
+        Random gen = RandomUtils.getRandom();
+        AVLGroupTree x = new AVLGroupTree(false);
+        for (int i = 0; i < 1000; ++i) {
+            x.add(gen.nextDouble(), 1 + gen.nextInt(10), null);
+        }
+        long sum = 0;
+        for (int node = x.first(); node != IntAVLTree.NIL; node = x.next(node)) {
+            assertEquals(sum, x.headSum(node));
+            sum += x.count(node);
+        }
+    }
+
+}

--- a/src/test/java/com/tdunning/math/stats/AVLTreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/AVLTreeDigestTest.java
@@ -1,0 +1,495 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import com.clearspring.analytics.stream.quantile.QDigest;
+import com.google.common.collect.Lists;
+
+import org.apache.mahout.common.RandomUtils;
+import org.apache.mahout.math.jet.random.AbstractContinousDistribution;
+import org.apache.mahout.math.jet.random.Gamma;
+import org.apache.mahout.math.jet.random.Normal;
+import org.apache.mahout.math.jet.random.Uniform;
+import org.junit.*;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
+public class AVLTreeDigestTest extends TDigestTest {
+
+    private DigestFactory<TDigest> factory = new DigestFactory<TDigest>() {
+        @Override
+        public TDigest create() {
+            return new AVLTreeDigest(100);
+        }
+    };
+
+    @Before
+    public void testSetUp() {
+        RandomUtils.useTestSeed();
+    }
+
+    @After
+    public void flush() {
+        sizeDump.flush();
+        errorDump.flush();
+        deviationDump.flush();
+    }
+
+    @Test
+    public void testUniform() {
+        Random gen = RandomUtils.getRandom();
+        for (int i = 0; i < repeats(); i++) {
+            runTest(factory, new Uniform(0, 1, gen), 100,
+                    new double[]{0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999},
+                    "uniform", true);
+        }
+    }
+
+    @Test
+    public void testGamma() {
+        // this Gamma distribution is very heavily skewed.  The 0.1%-ile is 6.07e-30 while
+        // the median is 0.006 and the 99.9th %-ile is 33.6 while the mean is 1.
+        // this severe skew means that we have to have positional accuracy that
+        // varies by over 11 orders of magnitude.
+        Random gen = RandomUtils.getRandom();
+        for (int i = 0; i < repeats(); i++) {
+            runTest(factory, new Gamma(0.1, 0.1, gen), 100,
+//                    new double[]{6.0730483624079e-30, 6.0730483624079e-20, 6.0730483627432e-10, 5.9339110446023e-03,
+//                            2.6615455373884e+00, 1.5884778179295e+01, 3.3636770117188e+01},
+                    new double[]{0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999},
+                    "gamma", true);
+        }
+    }
+
+    @Test
+    public void testNarrowNormal() {
+        // this mixture of a uniform and normal distribution has a very narrow peak which is centered
+        // near the median.  Our system should be scale invariant and work well regardless.
+        final Random gen = RandomUtils.getRandom();
+        AbstractContinousDistribution mix = new AbstractContinousDistribution() {
+            AbstractContinousDistribution normal = new Normal(0, 1e-5, gen);
+            AbstractContinousDistribution uniform = new Uniform(-1, 1, gen);
+
+            @Override
+            public double nextDouble() {
+                double x;
+                if (gen.nextDouble() < 0.5) {
+                    x = uniform.nextDouble();
+                } else {
+                    x = normal.nextDouble();
+                }
+                return x;
+            }
+        };
+
+        for (int i = 0; i < repeats(); i++) {
+            runTest(factory, mix, 100, new double[]{0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 0.99, 0.999}, "mixture", false);
+        }
+    }
+
+    @Test
+    public void testRepeatedValues() {
+        final Random gen = RandomUtils.getRandom();
+
+        // 5% of samples will be 0 or 1.0.  10% for each of the values 0.1 through 0.9
+        AbstractContinousDistribution mix = new AbstractContinousDistribution() {
+            @Override
+            public double nextDouble() {
+                return Math.rint(gen.nextDouble() * 10) / 10.0;
+            }
+        };
+
+        AVLTreeDigest dist = new AVLTreeDigest((double) 1000);
+        List<Double> data = Lists.newArrayList();
+        for (int i1 = 0; i1 < 100000; i1++) {
+            double x = mix.nextDouble();
+            data.add(x);
+        }
+
+        long t0 = System.nanoTime();
+        for (double x : data) {
+            dist.add(x);
+        }
+
+        System.out.printf("# %fus per point\n", (System.nanoTime() - t0) * 1e-3 / 100000);
+        System.out.printf("# %d centroids\n", dist.centroidCount());
+
+        // I would be happier with 5x compression, but repeated values make things kind of weird
+        assertTrue("Summary is too large: " + dist.centroidCount(), dist.centroidCount() < 10 * (double) 1000);
+
+        // all quantiles should round to nearest actual value
+        for (int i = 0; i < 10; i++) {
+            double z = i / 10.0;
+            // we skip over troublesome points that are nearly halfway between
+            for (double delta : new double[]{0.01, 0.02, 0.03, 0.07, 0.08, 0.09}) {
+                double q = z + delta;
+                double cdf = dist.cdf(q);
+                // we also relax the tolerances for repeated values
+                assertEquals(String.format("z=%.1f, q = %.3f, cdf = %.3f", z, q, cdf), z + 0.05, cdf, 0.01);
+
+                double estimate = dist.quantile(q);
+                assertEquals(String.format("z=%.1f, q = %.3f, cdf = %.3f, estimate = %.3f", z, q, cdf, estimate), Math.rint(q * 10) / 10.0, estimate, 0.001);
+            }
+        }
+    }
+
+    @Test
+    public void testSequentialPoints() {
+        for (int i = 0; i < repeats(); i++) {
+            runTest(factory, new AbstractContinousDistribution() {
+                double base = 0;
+
+                @Override
+                public double nextDouble() {
+                    base += Math.PI * 1e-5;
+                    return base;
+                }
+            }, 100, new double[]{0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999},
+                    "sequential", true);
+        }
+    }
+
+    @Test
+    public void testSerialization() {
+        Random gen = RandomUtils.getRandom();
+        AVLTreeDigest dist = new AVLTreeDigest(100);
+        for (int i = 0; i < 100000; i++) {
+            double x = gen.nextDouble();
+            dist.add(x);
+        }
+        dist.compress();
+
+        ByteBuffer buf = ByteBuffer.allocate(20000);
+        dist.asBytes(buf);
+        assertTrue(buf.position() < 11000);
+        assertEquals(buf.position(), dist.byteSize());
+        buf.clear();
+
+        dist.asSmallBytes(buf);
+        assertTrue(buf.position() < 6000);
+        assertEquals(buf.position(), dist.smallByteSize());
+
+        System.out.printf("# big %d bytes\n", buf.position());
+
+        buf.flip();
+        AVLTreeDigest dist2 = AVLTreeDigest.fromBytes(buf);
+        assertEquals(dist.centroidCount(), dist2.centroidCount());
+        assertEquals(dist.compression(), dist2.compression(), 0);
+        assertEquals(dist.size(), dist2.size());
+
+        for (double q = 0; q < 1; q += 0.01) {
+            assertEquals(dist.quantile(q), dist2.quantile(q), 1e-8);
+        }
+
+        Iterator<? extends Centroid> ix = dist2.centroids().iterator();
+        for (Centroid centroid : dist.centroids()) {
+            assertTrue(ix.hasNext());
+            assertEquals(centroid.count(), ix.next().count());
+        }
+        assertFalse(ix.hasNext());
+
+        buf.flip();
+        dist.asSmallBytes(buf);
+        assertTrue(buf.position() < 6000);
+        System.out.printf("# small %d bytes\n", buf.position());
+
+        buf.flip();
+        dist2 = AVLTreeDigest.fromBytes(buf);
+        assertEquals(dist.centroidCount(), dist2.centroidCount());
+        assertEquals(dist.compression(), dist2.compression(), 0);
+        assertEquals(dist.size(), dist2.size());
+
+        for (double q = 0; q < 1; q += 0.01) {
+            assertEquals(dist.quantile(q), dist2.quantile(q), 1e-6);
+        }
+
+        ix = dist2.centroids().iterator();
+        for (Centroid centroid : dist.centroids()) {
+            assertTrue(ix.hasNext());
+            assertEquals(centroid.count(), ix.next().count());
+        }
+        assertFalse(ix.hasNext());
+    }
+
+    @Test
+    public void testIntEncoding() {
+        Random gen = RandomUtils.getRandom();
+        ByteBuffer buf = ByteBuffer.allocate(10000);
+        List<Integer> ref = Lists.newArrayList();
+        for (int i = 0; i < 3000; i++) {
+            int n = gen.nextInt();
+            n = n >>> (i / 100);
+            ref.add(n);
+            AbstractTDigest.encode(buf, n);
+        }
+
+        buf.flip();
+
+        for (int i = 0; i < 3000; i++) {
+            int n = AbstractTDigest.decode(buf);
+            assertEquals(String.format("%d:", i), ref.get(i).intValue(), n);
+        }
+    }
+
+    @Test
+    public void compareToQDigest() throws FileNotFoundException {
+        Random rand = RandomUtils.getRandom();
+        PrintWriter out = new PrintWriter(new FileOutputStream("qd-tree-comparison.csv"));
+        try {
+            for (int i = 0; i < repeats(); i++) {
+                compareQD(out, new Gamma(0.1, 0.1, rand), "gamma", 1L << 48);
+                compareQD(out, new Uniform(0, 1, rand), "uniform", 1L << 48);
+            }
+        } finally {
+            out.close();
+        }
+    }
+
+    private void compareQD(PrintWriter out, AbstractContinousDistribution gen, String tag, long scale) {
+        for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000}) {
+            QDigest qd = new QDigest(compression);
+            AVLTreeDigest dist = new AVLTreeDigest(compression);
+            List<Double> data = Lists.newArrayList();
+            for (int i = 0; i < 100000; i++) {
+                double x = gen.nextDouble();
+                dist.add(x);
+                qd.offer((long) (x * scale));
+                data.add(x);
+            }
+            dist.compress();
+            Collections.sort(data);
+
+            for (double q : new double[]{0.001, 0.01, 0.1, 0.2, 0.3, 0.5, 0.7, 0.8, 0.9, 0.99, 0.999}) {
+                double x1 = dist.quantile(q);
+                double x2 = (double) qd.getQuantile(q) / scale;
+                double e1 = cdf(x1, data) - q;
+                out.printf("%s\t%.0f\t%.8f\t%.10g\t%.10g\t%d\t%d\n", tag, compression, q, e1, cdf(x2, data) - q, dist.smallByteSize(), QDigest.serialize(qd).length);
+
+            }
+        }
+    }
+
+    @Test
+    public void compareToStreamingQuantile() throws FileNotFoundException {
+        Random rand = RandomUtils.getRandom();
+
+        PrintWriter out = new PrintWriter(new FileOutputStream("sq-tree-comparison.csv"));
+        try {
+
+            for (int i = 0; i < repeats(); i++) {
+                compareSQ(out, new Gamma(0.1, 0.1, rand), "gamma", 1L << 48);
+                compareSQ(out, new Uniform(0, 1, rand), "uniform", 1L << 48);
+            }
+        } finally {
+            out.close();
+        }
+    }
+
+    private void compareSQ(PrintWriter out, AbstractContinousDistribution gen, String tag, long scale) {
+        double[] quantiles = {0.001, 0.01, 0.1, 0.2, 0.3, 0.5, 0.7, 0.8, 0.9, 0.99, 0.999};
+        for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000}) {
+            QuantileEstimator sq = new QuantileEstimator(1001);
+            AVLTreeDigest dist = new AVLTreeDigest(compression);
+            List<Double> data = Lists.newArrayList();
+            for (int i = 0; i < 100000; i++) {
+                double x = gen.nextDouble();
+                dist.add(x);
+                sq.add(x);
+                data.add(x);
+            }
+            dist.compress();
+            Collections.sort(data);
+
+            List<Double> qz = sq.getQuantiles();
+            for (double q : quantiles) {
+                double x1 = dist.quantile(q);
+                double x2 = qz.get((int) (q * 1000 + 0.5));
+                double e1 = cdf(x1, data) - q;
+                double e2 = cdf(x2, data) - q;
+                out.printf("%s\t%.0f\t%.8f\t%.10g\t%.10g\t%d\t%d\n",
+                        tag, compression, q, e1, e2, dist.smallByteSize(), sq.serializedSize());
+
+            }
+        }
+    }
+
+    @Test()
+    public void testSizeControl() throws IOException, InterruptedException, ExecutionException {
+        // very slow running data generator.  Don't want to run this normally.  To run slow tests use
+        // mvn test -DrunSlowTests=true
+        assumeTrue(Boolean.parseBoolean(System.getProperty("runSlowTests")));
+
+        final Random gen0 = RandomUtils.getRandom();
+        final PrintWriter out = new PrintWriter(new FileOutputStream("scaling.tsv"));
+        out.printf("k\tsamples\tcompression\tsize1\tsize2\n");
+
+        List<Callable<String>> tasks = Lists.newArrayList();
+        for (int k = 0; k < 20; k++) {
+            for (final int size : new int[]{10, 100, 1000, 10000}) {
+                final int currentK = k;
+                tasks.add(new Callable<String>() {
+                    Random gen = new Random(gen0.nextLong());
+
+                    @Override
+                    public String call() throws Exception {
+                        System.out.printf("Starting %d,%d\n", currentK, size);
+                        StringWriter s = new StringWriter();
+                        PrintWriter out = new PrintWriter(s);
+                        for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000}) {
+                            AVLTreeDigest dist = new AVLTreeDigest(compression);
+                            for (int i = 0; i < size * 1000; i++) {
+                                dist.add(gen.nextDouble());
+                            }
+                            out.printf("%d\t%d\t%.0f\t%d\t%d\n", currentK, size, compression, dist.smallByteSize(), dist.byteSize());
+                            out.flush();
+                        }
+                        out.close();
+                        return s.toString();
+                    }
+                });
+            }
+        }
+
+        for (Future<String> result : Executors.newFixedThreadPool(20).invokeAll(tasks)) {
+            out.write(result.get());
+        }
+
+        out.close();
+    }
+
+    @Test
+    public void testScaling() throws FileNotFoundException, InterruptedException, ExecutionException {
+        final Random gen0 = RandomUtils.getRandom();
+
+        PrintWriter out = new PrintWriter(new FileOutputStream("error-scaling.tsv"));
+        try {
+            out.printf("pass\tcompression\tq\terror\tsize\n");
+
+            Collection<Callable<String>> tasks = Lists.newArrayList();
+            int n = Math.max(3, repeats() * repeats());
+            for (int k = 0; k < n; k++) {
+                final int currentK = k;
+                tasks.add(new Callable<String>() {
+                    Random gen = new Random(gen0.nextLong());
+
+                    @Override
+                    public String call() throws Exception {
+                        System.out.printf("Start %d\n", currentK);
+                        StringWriter s = new StringWriter();
+                        PrintWriter out = new PrintWriter(s);
+
+                        List<Double> data = Lists.newArrayList();
+                        for (int i = 0; i < 100000; i++) {
+                            data.add(gen.nextDouble());
+                        }
+                        Collections.sort(data);
+
+                        for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000}) {
+                            AVLTreeDigest dist = new AVLTreeDigest(compression);
+                            for (Double x : data) {
+                                dist.add(x);
+                            }
+                            dist.compress();
+
+                            for (double q : new double[]{0.001, 0.01, 0.1, 0.5}) {
+                                double estimate = dist.quantile(q);
+                                double actual = data.get((int) (q * data.size()));
+                                out.printf("%d\t%.0f\t%.3f\t%.9f\t%d\n", currentK, compression, q, estimate - actual, dist.byteSize());
+                                out.flush();
+                            }
+                        }
+                        out.close();
+                        System.out.printf("Finish %d\n", currentK);
+
+                        return s.toString();
+                    }
+                });
+            }
+
+            ExecutorService exec = Executors.newFixedThreadPool(16);
+            for (Future<String> result : exec.invokeAll(tasks)) {
+                out.write(result.get());
+            }
+        } finally {
+            out.close();
+        }
+    }
+
+    @Test
+    public void testMerge() throws FileNotFoundException, InterruptedException, ExecutionException {
+        merge(new DigestFactory<AVLTreeDigest>() {
+            @Override
+            public AVLTreeDigest create() {
+                return new AVLTreeDigest(50);
+            }
+        });
+    }
+
+    @Test
+    public void testEmpty() {
+        empty(new AVLTreeDigest(100));
+    }
+
+    @Test
+    public void testSingleValue() {
+        singleValue(new AVLTreeDigest(100));
+    }
+
+    @Test
+    public void testFewValues() {
+        final TDigest digest = new AVLTreeDigest(100);
+        fewValues(digest);
+    }
+
+    @Test
+    public void testMoreThan2BValues() {
+        final TDigest digest = new AVLTreeDigest(100);
+        moreThan2BValues(digest);
+    }
+
+    @Test
+    public void testExtremeQuantiles() {
+        // t-digest shouldn't merge extreme nodes, but let's still test how it would
+        // answer to extreme quantiles in that case ('extreme' in the sense that the
+        // quantile is either before the first node or after the last one)
+        AVLTreeDigest digest = new AVLTreeDigest(100);
+        // we need to create the GroupTree manually
+        AVLGroupTree tree = (AVLGroupTree) digest.centroids();
+        Centroid g = new Centroid(10);
+        tree.add(10, 3, null);
+        tree.add(20, 1, null);
+        tree.add(40, 5, null);
+        digest.count = 3 + 1 + 5;
+        // this group tree is roughly equivalent to the following sorted array:
+        // [ ?, 10, ?, 20, ?, ?, 50, ?, ? ]
+        // and we expect it to compute approximate missing values:
+        // [ 5, 10, 15, 20, 30, 40, 50, 60, 70]
+        List<Double> values = Arrays.asList(5., 10., 15., 20., 30., 40., 50., 60., 70.);
+        for (int i = 0; i < digest.size(); ++i) {
+            final double q = 1.0 / (digest.size() - 1); // a quantile that matches an array index
+            assertEquals(quantile(q, values), digest.quantile(q), 0.01);
+        }
+    }
+
+}

--- a/src/test/java/com/tdunning/math/stats/IntAVLTreeTest.java
+++ b/src/test/java/com/tdunning/math/stats/IntAVLTreeTest.java
@@ -1,0 +1,124 @@
+package com.tdunning.math.stats;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+
+import org.junit.Test;
+
+
+public class IntAVLTreeTest {
+
+    static class IntBag extends IntAVLTree {
+
+        int value;
+        int[] values;
+        int[] counts;
+
+        IntBag() {
+            values = new int[capacity()];
+            counts = new int[capacity()];
+        }
+
+        public boolean addValue(int value) {
+            this.value = value;
+            return super.add();
+        }
+
+        public boolean removeValue(int value) {
+            this.value = value;
+            final int node = find();
+            if (node == NIL) {
+                return false;
+            } else {
+                super.remove(node);
+                return true;
+            }
+        }
+
+        @Override
+        protected void resize(int newCapacity) {
+            super.resize(newCapacity);
+            values = Arrays.copyOf(values, newCapacity);
+            counts = Arrays.copyOf(counts, newCapacity);
+        }
+
+        @Override
+        protected int compare(int node) {
+            return value - values[node];
+        }
+
+        @Override
+        protected void copy(int node) {
+            values[node] = value;
+            counts[node] = 1;
+        }
+
+        @Override
+        protected void merge(int node) {
+            values[node] = value;
+            counts[node]++;
+        }
+
+    }
+
+    @Test
+    public void duelAdd() {
+        Random r = new Random(0);
+        TreeMap<Integer, Integer> map = new TreeMap<Integer, Integer>();
+        IntBag bag = new IntBag();
+        for (int i = 0; i < 100000; ++i) {
+            final int v = r.nextInt(100000);
+            if (map.containsKey(v)) {
+                map.put(v, map.get(v) + 1);
+                assertFalse(bag.addValue(v));
+            } else {
+                map.put(v, 1);
+                assertTrue(bag.addValue(v));
+            }
+        }
+        Iterator<Map.Entry<Integer, Integer>> it = map.entrySet().iterator();
+        for (int node = bag.first(bag.root()); node != IntAVLTree.NIL; node = bag.next(node)) {
+            final Map.Entry<Integer, Integer> next = it.next();
+            assertEquals(next.getKey().intValue(), bag.values[node]);
+            assertEquals(next.getValue().intValue(), bag.counts[node]);
+        }
+        assertFalse(it.hasNext());
+    }
+
+    @Test
+    public void duelAddRemove() {
+        Random r = new Random(0);
+        TreeMap<Integer, Integer> map = new TreeMap<Integer, Integer>();
+        IntBag bag = new IntBag();
+        for (int i = 0; i < 100000; ++i) {
+            final int v = r.nextInt(1000);
+            if (r.nextBoolean()) {
+                // add
+                if (map.containsKey(v)) {
+                    map.put(v, map.get(v) + 1);
+                    assertFalse(bag.addValue(v));
+                } else {
+                    map.put(v, 1);
+                    assertTrue(bag.addValue(v));
+                }
+            } else {
+                // remove
+                assertEquals(map.remove(v) != null, bag.removeValue(v));
+            }
+        }
+        Iterator<Map.Entry<Integer, Integer>> it = map.entrySet().iterator();
+        for (int node = bag.first(bag.root()); node != IntAVLTree.NIL; node = bag.next(node)) {
+            final Map.Entry<Integer, Integer> next = it.next();
+            assertEquals(next.getKey().intValue(), bag.values[node]);
+            assertEquals(next.getValue().intValue(), bag.counts[node]);
+        }
+        assertFalse(it.hasNext());
+    }
+
+}


### PR DESCRIPTION
Improved tree-based t-digest, with the following changes compared to the
previous implementation:
- the array structure is stored in parallel arrays instead of a tree of
  objects,
- data is stored both on inner nodes and leaf nodes,
- data is updated in-place when this would not trigger a reordering
  of the tree (possible by tracking parents).

Simplistic benchmarks seem to suggest this is a faster than the current
ArrayDigest implementation.

I don't consider it ready yet: even if it passes the test suite, I need to spend
more time making sure it works correctly, but I'd be happy to have your feedback
about whether it is a good idea to work on the tree-based implementation
(I saw in a previous comment that you are considering deprecating the tree
digest, but if my understanding is correct, this is more because it currently stores
Centroids objects than because it is a tree?). The code might not be very easy to
digest so feel free to ask any questions!
