### PR TITLE
Faster quantile estimations.

### DIFF
--- a/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
+++ b/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
@@ -109,6 +109,13 @@ final class AVLGroupTree implements Iterable<Centroid> {
     }
 
     /**
+     * Return the previous node.
+     */
+    public int prev(int node) {
+        return tree.prev(node);
+    }
+
+    /**
      * Return the next node.
      */
     public int next(int node) {
@@ -172,6 +179,26 @@ final class AVLGroupTree implements Iterable<Centroid> {
             } else {
                 floor = node;
                 node = tree.right(node);
+            }
+        }
+        return floor;
+    }
+
+    /**
+     * Return the last node so that the sum of counts of nodes that are before
+     * it is less than or equal to <code>sum</code>.
+     */
+    public int floorSum(long sum) {
+        int floor = IntAVLTree.NIL;
+        for (int node = tree.root(); node != IntAVLTree.NIL; ) {
+            final int left = tree.left(node);
+            final long leftCount = aggregatedCounts[left];
+            if (leftCount <= sum) {
+                floor = node;
+                sum -= leftCount + count(node);
+                node = tree.right(node);
+            } else {
+                node = tree.left(node);
             }
         }
         return floor;

--- a/src/test/java/com/tdunning/math/stats/AVLGroupTreeTest.java
+++ b/src/test/java/com/tdunning/math/stats/AVLGroupTreeTest.java
@@ -18,6 +18,7 @@
 package com.tdunning.math.stats;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Random;
 
@@ -91,6 +92,25 @@ public class AVLGroupTreeTest {
         for (int node = x.first(); node != IntAVLTree.NIL; node = x.next(node)) {
             assertEquals(sum, x.headSum(node));
             sum += x.count(node);
+        }
+    }
+
+    @Test
+    public void testFloorSum() {
+        Random gen = RandomUtils.getRandom();
+        AVLGroupTree x = new AVLGroupTree(false);
+        int total = 0;
+        for (int i = 0; i < 1000; ++i) {
+            int count = 1 + gen.nextInt(10);
+            x.add(gen.nextDouble(), count, null);
+            total += count;
+        }
+        assertEquals(IntAVLTree.NIL, x.floorSum(-1));
+        for (long i = 0; i < total + 10; ++i) {
+            final int floorNode = x.floorSum(i);
+            assertTrue(x.headSum(floorNode) <= i);
+            final int next = x.next(floorNode);
+            assertTrue(next == IntAVLTree.NIL || x.headSum(next) > i);
         }
     }
 


### PR DESCRIPTION
Quantile estimation is currently linear with the number of centroids. However
it is possible to compute quantiles in logarithmic time by using the aggregated
counts that are stored on each node and running a binary search.

The quantile estimation method has also been improved in order to not
materialize objects anymore.

It doesn't matter much if you use t-digest with a batch approach and first
accumulate all values before computing quantiles in a final step. But this
speedup means that it is now possible to interleave accumulation and quantile
estimation without killing performance.
