### PR TITLE
Fix ArrayDigest ordering when the page size is not a multiple of 2.

### DIFF
--- a/src/main/java/com/tdunning/math/stats/ArrayDigest.java
+++ b/src/main/java/com/tdunning/math/stats/ArrayDigest.java
@@ -792,7 +792,7 @@ public class ArrayDigest extends AbstractTDigest {
             if (active >= pageSize) {
                 // split page
                 Page newPage = split();
-                newPage.addAt(pageSize / 2, x, w, history);
+                newPage.addAt(newPage.active, x, w, history);
                 return newPage;
             } else {
                 addAt(active, x, w, history);

--- a/src/test/java/com/tdunning/math/stats/AVLTreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/AVLTreeDigestTest.java
@@ -492,4 +492,9 @@ public class AVLTreeDigestTest extends TDigestTest {
         }
     }
 
+    @Test
+    public void testSorted() {
+        final TDigest digest = factory.create();
+        sorted(digest);
+    }
 }

--- a/src/test/java/com/tdunning/math/stats/ArrayDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/ArrayDigestTest.java
@@ -606,4 +606,10 @@ public class ArrayDigestTest extends TDigestTest {
         moreThan2BValues(digest);
     }
 
+    @Test
+    public void testSorted() {
+        final TDigest digest = factory.create();
+        sorted(digest);
+    }
+
 }

--- a/src/test/java/com/tdunning/math/stats/TDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestTest.java
@@ -353,4 +353,18 @@ public class TDigestTest {
     public interface DigestFactory<T extends TDigest> {
         T create();
     }
+
+    protected void sorted(TDigest digest) {
+        Random gen = RandomUtils.getRandom();
+        for (int i = 0; i < 10000; ++i) {
+            digest.add(gen.nextDouble(), 1 + gen.nextInt(10));
+        }
+        Centroid previous = null;
+        for (Centroid centroid : digest.centroids()) {
+            if (previous != null) {
+                assertTrue(previous.mean() <= centroid.mean());
+            }
+            previous = centroid;
+        }
+    }
 }

--- a/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
@@ -496,4 +496,9 @@ public class TreeDigestTest extends TDigestTest {
         }
     }
 
+    @Test
+    public void testSorted() {
+        final TDigest digest = factory.create();
+        sorted(digest);
+    }
 }


### PR DESCRIPTION
ArrayDigest might insert centroids out of order when the page size is not a multiple of 2. This is not a big deal in practice since most users probably use the default page size of 32.
