### PR TITLE
Fail addition of Double.NaN to a TDigest instance.

### DIFF
--- a/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
@@ -66,6 +66,7 @@ public class AVLTreeDigest extends AbstractTDigest {
     }
 
     public void add(double x, int w, List<Double> data) {
+        checkValue(x);
         int start = summary.floor(x);
         if (start == IntAVLTree.NIL) {
             start = summary.first();

--- a/src/main/java/com/tdunning/math/stats/ArrayDigest.java
+++ b/src/main/java/com/tdunning/math/stats/ArrayDigest.java
@@ -51,6 +51,7 @@ public class ArrayDigest extends AbstractTDigest {
 
     @Override
     public void add(double x, int w) {
+        checkValue(x);
         Index start = floor(x);
         if (start == null) {
             start = ceiling(x);

--- a/src/main/java/com/tdunning/math/stats/TDigest.java
+++ b/src/main/java/com/tdunning/math/stats/TDigest.java
@@ -82,6 +82,12 @@ public abstract class TDigest {
      */
     public abstract void add(double x, int w);
 
+    protected final void checkValue(double x) {
+        if (Double.isNaN(x)) {
+            throw new IllegalArgumentException("Cannot add NaN");
+        }
+    }
+
     /**
      * Re-examines a t-digest to determine whether some centroids are redundant.  If your data are
      * perversely ordered, this may be a good idea.  Even if not, this may save 20% or so in space.

--- a/src/main/java/com/tdunning/math/stats/TreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/TreeDigest.java
@@ -69,6 +69,7 @@ public class TreeDigest extends AbstractTDigest {
 
     @Override
     public void add(double x, int w, Centroid base) {
+        checkValue(x);
         Centroid start = summary.floor(base);
         if (start == null) {
             start = summary.ceiling(base);

--- a/src/test/java/com/tdunning/math/stats/AVLTreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/AVLTreeDigestTest.java
@@ -497,4 +497,10 @@ public class AVLTreeDigestTest extends TDigestTest {
         final TDigest digest = factory.create();
         sorted(digest);
     }
+
+    @Test
+    public void testNaN() {
+        final TDigest digest = factory.create();
+        nan(digest);
+    }
 }

--- a/src/test/java/com/tdunning/math/stats/ArrayDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/ArrayDigestTest.java
@@ -612,4 +612,9 @@ public class ArrayDigestTest extends TDigestTest {
         sorted(digest);
     }
 
+    @Test
+    public void testNaN() {
+        final TDigest digest = factory.create();
+        nan(digest);
+    }
 }

--- a/src/test/java/com/tdunning/math/stats/TDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestTest.java
@@ -44,6 +44,8 @@ import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 
 /**
  * Common test methods for TDigests
@@ -368,6 +370,25 @@ public class TDigestTest {
                 assertTrue(previous.mean() <= centroid.mean());
             }
             previous = centroid;
+        }
+    }
+
+    protected void nan(TDigest digest) {
+        Random gen = RandomUtils.getRandom();
+        final int iters = gen.nextInt(100);
+        for (int i = 0; i < iters; ++i) {
+            digest.add(gen.nextDouble(), 1 + gen.nextInt(10));
+        }
+        try {
+            // both versions should fail
+            if (gen.nextBoolean()) {
+                digest.add(Double.NaN);
+            } else {
+                digest.add(Double.NaN, 1);
+            }
+            fail("NaN should be an illegal argument");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
     }
 }

--- a/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
@@ -501,4 +501,10 @@ public class TreeDigestTest extends TDigestTest {
         final TDigest digest = factory.create();
         sorted(digest);
     }
+
+    @Test
+    public void testNaN() {
+        final TDigest digest = factory.create();
+        nan(digest);
+    }
 }


### PR DESCRIPTION
We rely on the fact that values must be comparable, yet Double.NaN compares
unequal to any value (even Double.NaN itself). So we should reject it instead
or corrupting the internal state of the digest instances.
