### PR TITLE
Add a Caliper benchmark.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
             <version>1.0-beta-1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.carrotsearch</groupId>
+            <artifactId>java-sizeof</artifactId>
+            <version>0.0.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/test/java/com/tdunning/math/stats/TDigestBenchmark.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestBenchmark.java
@@ -17,7 +17,7 @@ public class TDigestBenchmark extends Benchmark {
 
     private static final int ARRAY_PAGE_SIZE = 32;
 
-    private static enum TDigestFactory {
+    static enum TDigestFactory {
         ARRAY {
             @Override
             TDigest create(double compression) {

--- a/src/test/java/com/tdunning/math/stats/TDigestMemoryBenchmark.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestMemoryBenchmark.java
@@ -1,0 +1,32 @@
+package com.tdunning.math.stats;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.carrotsearch.sizeof.RamUsageEstimator;
+import com.tdunning.math.stats.TDigestBenchmark.TDigestFactory;
+
+public class TDigestMemoryBenchmark {
+
+    private static final double COMPRESSION = 100;
+
+    public static void main(String[] args) {
+        System.out.println("Average bytes per centroid");
+        System.out.println("==========================");
+        Random random = ThreadLocalRandom.current();
+        for (TDigestFactory factory : TDigestBenchmark.TDigestFactory.values()) {
+            TDigest tdigest = factory.create(COMPRESSION);
+            // Use a uniform distribution to know the average case
+            for (int i = 0; i < 10000; ++i) {
+                tdigest.add(random.nextDouble());
+            }
+            System.out.println(factory + "\t" + memoryUsagePerCentroid(tdigest));
+        }
+    }
+
+    private static double memoryUsagePerCentroid(TDigest tdigest) {
+        final long totalSize = RamUsageEstimator.sizeOf(tdigest);
+        return (double) totalSize / tdigest.centroidCount();
+    }
+
+}


### PR DESCRIPTION
Here are results of this benchmark on my machine:
https://microbenchmarks.appspot.com/runs/d36c7051-08ae-46c6-9b77-d668e9a6dac5#r:scenario.benchmarkSpec.methodName,scenario.benchmarkSpec.parameters.compression,scenario.benchmarkSpec.parameters.distributionFactory,scenario.benchmarkSpec.parameters.tdigestFactory

It suggests several things:
- TreeDigest is very slow,
- ArrayDigest is slow on high values of compression (as expected),
- AVLTreeDigest is slightly faster than ArrayDigest on average, and better reacts to worst cases (sequential points),
- if you need to frequently compute quantiles, AVLTreeDigest is your best option.
