### PR TITLE
Compress TDigest instances more aggressively.

### DIFF
--- a/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
@@ -129,7 +129,7 @@ public class AVLTreeDigest extends AbstractTDigest {
             }
             count += w;
 
-            if (summary.size() > 100 * compression) {
+            if (summary.size() > 20 * compression) {
                 // may happen in case of sequential points
                 compress();
             }

--- a/src/main/java/com/tdunning/math/stats/ArrayDigest.java
+++ b/src/main/java/com/tdunning/math/stats/ArrayDigest.java
@@ -143,7 +143,7 @@ public class ArrayDigest extends AbstractTDigest {
                 }
             }
 
-            if (centroidCount > 100 * compression) {
+            if (centroidCount > 20 * compression) {
                 // something such as sequential ordering of data points
                 // has caused a pathological expansion of our summary.
                 // To fight this, we simply replay the current centroids

--- a/src/main/java/com/tdunning/math/stats/TreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/TreeDigest.java
@@ -128,7 +128,7 @@ public class TreeDigest extends AbstractTDigest {
             }
             count += w;
 
-            if (summary.size() > 100 * compression) {
+            if (summary.size() > 20 * compression) {
                 // something such as sequential ordering of data points
                 // has caused a pathological expansion of our summary.
                 // To fight this, we simply replay the current centroids


### PR DESCRIPTION
TDigest instances are expected to track about 5_compression centroids. Yet they
get compressed only when the number of centroids grows larger than
100_compression.

I did some experiments with lower thresholds, and it seems to behave rather
well. In particular, with a threshold of 20*compression (computed empirically),
I get:
1. a slowdown of ~30% for sequential points (but memory usage is reduced by 5x)
2. a speedup that can be significant (especially for ArrayDigest, I have seen
   speedups up to 50%) for data distributions whose amplitude is slowly
   expanding.

All in all, I think lowering the threshold to 20*compression would be a better
trade-off?
