### PR TITLE
fix for merging newly created empty TDigest

### DIFF
--- a/src/main/java/com/tdunning/math/stats/GroupTree.java
+++ b/src/main/java/com/tdunning/math/stats/GroupTree.java
@@ -225,7 +225,7 @@ public class GroupTree implements Iterable<Centroid> {
                 if (next == null) {
                     next = computeNext();
                 }
-                return next != end;
+                return next != null && next != end;
             }
 
             @Override

--- a/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
@@ -447,6 +447,16 @@ public class TreeDigestTest extends TDigestTest {
     }
 
     @Test
+    public void testMergeEmpty() {
+        final Random gen0 = RandomUtils.getRandom();
+        List<TDigest> subData = new ArrayList();
+        subData.add(new TreeDigest(10));
+        TreeDigest foo = new TreeDigest(10);
+        AbstractTDigest.merge(subData, gen0, foo);
+        empty(foo);
+    }
+
+    @Test
     public void testEmpty() {
         empty(new TreeDigest(100));
     }


### PR DESCRIPTION
fix for the following exception:
java.util.NoSuchElementException: Can't iterate past end of data
    at com.tdunning.math.stats.GroupTree$1.next(GroupTree.java:238)
    at com.tdunning.math.stats.GroupTree$1.next(GroupTree.java:212)
    at com.tdunning.math.stats.AbstractTDigest.merge(AbstractTDigest.java:69)
