### PR TITLE
Add a new t-digest impl: BatchDigest.

### DIFF
--- a/src/main/java/com/tdunning/math/stats/AbstractTDigest.java
+++ b/src/main/java/com/tdunning/math/stats/AbstractTDigest.java
@@ -20,6 +20,7 @@ package com.tdunning.math.stats;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
@@ -131,5 +132,103 @@ public abstract class AbstractTDigest extends TDigest {
 
     protected Centroid createCentroid(double mean, int id) {
         return new Centroid(mean, id, recordAllData);
+    }
+
+    @Override
+    public double quantile(double q) {
+        if (q < 0 || q > 1) {
+            throw new IllegalArgumentException("q should be in [0,1], got " + q);
+        }
+
+        final int centroidCount = centroids().size();
+        if (centroidCount == 0) {
+            return Double.NaN;
+        } else if (centroidCount == 1) {
+            return centroids().iterator().next().mean();
+        }
+
+        // if values were stored in a sorted array, index would be the offset we are interested in
+        final double index = q * (size() - 1);
+
+        double previousMean = Double.NaN, previousIndex = 0;
+        long total = 0;
+        // Jump over pages until we reach the page containing the quantile we are interested in
+        Iterator<? extends Centroid> it = centroids().iterator();
+        Centroid next;
+        while (true) {
+            next = it.next();
+            final double nextIndex = total + (next.count() - 1.0) / 2;
+            if (nextIndex >= index) {
+                if (Double.isNaN(previousMean)) {
+                    assert total == 0;
+                    // special case 1: the index we are interested in is before the 1st centroid
+                    if (nextIndex == previousIndex) {
+                        return next.mean();
+                    }
+                    // assume values grow linearly between index previousIndex=0 and nextIndex2
+                    Centroid next2 = it.next();
+                    final double nextIndex2 = total + next.count() + (next2.count() - 1.0) / 2;
+                    previousMean = (nextIndex2 * next.mean() - nextIndex * next2.mean()) / (nextIndex2 - nextIndex);
+                }
+                // common case: we found two centroids previous and next so that the desired quantile is
+                // after 'previous' but before 'next'
+                return quantile(previousIndex, index, nextIndex, previousMean, next.mean());
+            } else if (!it.hasNext()) {
+                // special case 2: the index we are interested in is beyond the last centroid
+                // again, assume values grow linearly between index previousIndex and (count - 1)
+                // which is the highest possible index
+                final double nextIndex2 = size() - 1;
+                final double nextMean2 = (next.mean() * (nextIndex2 - previousIndex) - previousMean * (nextIndex2 - nextIndex)) / (nextIndex - previousIndex);
+                return quantile(nextIndex, index, nextIndex2, next.mean(), nextMean2);
+            }
+            total += next.count();
+            previousMean = next.mean();
+            previousIndex = nextIndex;
+        }
+    }
+
+    @Override
+    public double cdf(double x) {
+        if (size() == 0) {
+            return Double.NaN;
+        } else if (size() == 1) {
+            return x < centroids().iterator().next().mean() ? 0 : 1;
+        } else {
+            double r = 0;
+
+            // we scan a across the centroids
+            Iterator<? extends Centroid> it = centroids().iterator();
+            Centroid a = it.next();
+
+            // b is the look-ahead to the next centroid
+            Centroid b = it.next();
+
+            // initially, we set left width equal to right width
+            double left = (b.mean() - a.mean()) / 2;
+            double right = left;
+
+            // scan to next to last element
+            while (it.hasNext()) {
+                if (x < a.mean() + right) {
+                    return (r + a.count() * AbstractTDigest.interpolate(x, a.mean() - left, a.mean() + right)) / size();
+                }
+                r += a.count();
+
+                a = b;
+                b = it.next();
+
+                left = right;
+                right = (b.mean() - a.mean()) / 2;
+            }
+
+            // for the last element, assume right width is same as left
+            left = right;
+            a = b;
+            if (x < a.mean() + right) {
+                return (r + a.count() * AbstractTDigest.interpolate(x, a.mean() - left, a.mean() + right)) / size();
+            } else {
+                return 1;
+            }
+        }
     }
 }

--- a/src/main/java/com/tdunning/math/stats/BatchTDigest.java
+++ b/src/main/java/com/tdunning/math/stats/BatchTDigest.java
@@ -1,0 +1,204 @@
+package com.tdunning.math.stats;
+
+import java.nio.ByteBuffer;
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.List;
+
+
+public class BatchTDigest extends AbstractTDigest {
+
+    private final double compression;
+    private Histogram buffer = new Histogram(recordAllData);
+    private Histogram main = new Histogram(recordAllData);
+    private Histogram spare = new Histogram(recordAllData);
+
+    public BatchTDigest(double compression) {
+        this.compression = compression;
+    }
+    
+    @Override
+    public TDigest recordAllData() {
+        if (buffer.length() + main.length() != 0) {
+            throw new IllegalStateException("Can only ask to record added data on an empty summary");
+        }
+        super.recordAllData();
+        buffer = new Histogram(recordAllData);
+        main = new Histogram(recordAllData);
+        spare = new Histogram(recordAllData);
+        return this;
+    }
+
+    @Override
+    void add(double x, int w, Centroid base) {
+        if (x != base.mean() || w != base.count()) {
+            throw new IllegalArgumentException();
+        }
+        add(x, w, base.data());
+    }
+
+    @Override
+    public void add(double x, int w) {
+        add(x, w, (List<Double>) null);
+    }
+    
+    private void merge() {
+        if (buffer.length() > 0) {
+            buffer.sort();
+            Histogram.merge(buffer, main, spare);
+            buffer.reset();
+
+            main.reset();
+            Histogram.compact(spare, main, compression);
+            spare.reset();
+        }
+    }
+    
+    public void add(double x, int w, List<Double> data) {
+        checkValue(x);
+        buffer.append(x, w, data);
+        if (buffer.length() >= main.length()) {
+            merge();
+
+            if (main.length() > 10 * compression) {
+                compress();
+            }
+        }
+    }
+
+    @Override
+    public void compress() {
+        Histogram.compact(main, spare, compression);
+        main.reset();
+        Histogram.compact(spare, main, compression);
+        spare.reset();
+    }
+
+    @Override
+    public long size() {
+        return main.totalCount() + buffer.totalCount();
+    }
+
+    @Override
+    public Collection<Centroid> centroids() {
+        merge();
+        return new AbstractList<Centroid>() {
+            @Override
+            public Centroid get(int index) {
+                Centroid centroid = new Centroid(main.mean(index), main.count(index), index);
+                final List<Double> data = main.data(index);
+                if (data != null) {
+                    for (double d : data) {
+                        centroid.insertData(d);
+                    }
+                }
+                return centroid;
+            }
+
+            @Override
+            public int size() {
+                return main.length();
+            }
+        };
+    }
+
+    @Override
+    public double compression() {
+        return compression;
+    }
+
+    @Override
+    public int byteSize() {
+        merge();
+        return 4 + 8 + 4 + main.length() * 12;
+    }
+
+    @Override
+    public int smallByteSize() {
+        int bound = byteSize();
+        ByteBuffer buf = ByteBuffer.allocate(bound);
+        asSmallBytes(buf);
+        return buf.position();
+    }
+
+    public final static int VERBOSE_ENCODING = 1;
+    public final static int SMALL_ENCODING = 2;
+
+    /**
+     * Outputs a histogram as bytes using a particularly cheesy encoding.
+     */
+    @Override
+    public void asBytes(ByteBuffer buf) {
+        merge();
+        buf.putInt(VERBOSE_ENCODING);
+        buf.putDouble(compression());
+        buf.putInt(centroids().size());
+        for (Centroid centroid : centroids()) {
+            buf.putDouble(centroid.mean());
+        }
+
+        for (Centroid centroid : centroids()) {
+            buf.putInt(centroid.count());
+        }
+    }
+
+    @Override
+    public void asSmallBytes(ByteBuffer buf) {
+        buf.putInt(SMALL_ENCODING);
+        buf.putDouble(compression());
+        buf.putInt(centroids().size());
+
+        double x = 0;
+        for (Centroid centroid : centroids()) {
+            double delta = centroid.mean() - x;
+            x = centroid.mean();
+            buf.putFloat((float) delta);
+        }
+
+        for (Centroid centroid : centroids()) {
+            int n = centroid.count();
+            encode(buf, n);
+        }
+    }
+
+    /**
+     * Reads a histogram from a byte buffer
+     *
+     * @return The new histogram structure
+     */
+    public static BatchTDigest fromBytes(ByteBuffer buf) {
+        int encoding = buf.getInt();
+        if (encoding == VERBOSE_ENCODING) {
+            double compression = buf.getDouble();
+            BatchTDigest r = new BatchTDigest(compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            for (int i = 0; i < n; i++) {
+                means[i] = buf.getDouble();
+            }
+            for (int i = 0; i < n; i++) {
+                r.main.append(means[i], buf.getInt(), null);
+            }
+            return r;
+        } else if (encoding == SMALL_ENCODING) {
+            double compression = buf.getDouble();
+            BatchTDigest r = new BatchTDigest(compression);
+            int n = buf.getInt();
+            double[] means = new double[n];
+            double x = 0;
+            for (int i = 0; i < n; i++) {
+                double delta = buf.getFloat();
+                x += delta;
+                means[i] = x;
+            }
+
+            for (int i = 0; i < n; i++) {
+                int z = decode(buf);
+                r.main.append(means[i], z, null);
+            }
+            return r;
+        } else {
+            throw new IllegalStateException("Invalid format for serialized histogram");
+        }
+    }
+}

--- a/src/main/java/com/tdunning/math/stats/Histogram.java
+++ b/src/main/java/com/tdunning/math/stats/Histogram.java
@@ -1,0 +1,270 @@
+package com.tdunning.math.stats;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+final class Histogram implements Iterable<Centroid> {
+
+    /**
+     * Merge sort src1 and src2 into dest.
+     */
+    public static void merge(Histogram src1, Histogram src2, Histogram dest) {
+        assert dest.length() == 0;
+        final int len1 = src1.length();
+        final int len2 = src2.length();
+        int i = 0;
+        int j = 0;
+        while (i < len1 && j < len2) {
+            final double mean1 = src1.mean(i);
+            final double mean2 = src2.mean(j);
+            if (src1.mean(i) < src2.mean(j)) {
+                dest.append(mean1, src1.count(i), src1.data(i));
+                i += 1;
+            } else {
+                dest.append(mean2, src2.count(j), src2.data(j));
+                j += 1;
+            }
+        }
+        while (i < len1) {
+            dest.append(src1.mean(i), src1.count(i), src1.data(i));
+            i += 1;
+        }
+        while (j < len2) {
+            dest.append(src2.mean(j), src2.count(j), src2.data(j));
+            j += 1;
+        }
+    }
+
+    private static double weightedAverage(double d1, int w1, double d2, int w2) {
+        assert d1 <= d2;
+        final double average = (d1 * w1 + d2 * w2) / (w1 + w2);
+        // the below line exists because of floating-point rounding errors, for
+        // the compact method we need the order to be maintained!
+        return Math.max(d1, Math.min(average, d2));
+    }
+
+    /** Compress <code>src</code> into <code>dest</code>. */
+    public static void compact(Histogram src, Histogram dest, double compression) {
+        // The key here is that this method is guaranteed to maintain order since
+        // we only merge adjacent keys and the histogram is sorted
+        assert dest.length() == 0;
+        assert src.sorted();
+        final long totalCount = src.totalCount();
+        double currentMean = Double.NaN;
+        int currentCount = 0;
+        final boolean recordPoints = src.data != null;
+        List<Double> currentPoints = null;
+        for (int srcIdx = 0, length = src.length(); srcIdx < length; ++srcIdx) {
+            final double mean = src.mean(srcIdx);
+            final int count = src.count(srcIdx);
+            final List<Double> points = src.data(srcIdx);
+
+            if (Double.isNaN(currentMean)) {
+                currentMean = mean;
+                currentCount = count;
+                currentPoints = points;
+            } else if (srcIdx == length - 1 || mean - currentMean <= src.mean(srcIdx + 1) - mean) {
+                // the current mean is the closest mean, try to merge
+                final double q = totalCount == 1 ? 0.5 : (dest.totalCount() + (currentCount + count - 1) / 2.0) / (totalCount - 1);
+                final double k = 4 * totalCount * q * (1 - q) / compression;
+                if (count + currentCount <= k) {
+                    // count is ok => merge
+                    currentMean = weightedAverage(currentMean, currentCount, mean, count);
+                    currentCount += count;
+                    if (recordPoints) {
+                        currentPoints.addAll(points);
+                    }
+                } else {
+                    // count is too high => don't merge
+                    dest.append(currentMean, currentCount, currentPoints);
+                    dest.append(mean, count, points);
+                    currentMean = Double.NaN;
+                }
+            } else {
+                // the next mean is closer, flush
+                dest.append(currentMean, currentCount, currentPoints);
+                currentMean = mean;
+                currentCount = count;
+                currentPoints = points;
+            }
+        }
+        if (Double.isNaN(currentMean) == false) {
+            dest.append(currentMean, currentCount, currentPoints);
+        }
+    }
+
+    private double[] means;
+    private int[] counts;
+    private List<Double>[] data;
+    private long totalCount;
+    private int length;
+
+    Histogram(boolean record) {
+        means = new double[8];
+        counts = new int[8];
+        if (record) {
+            data = new List[8];
+        } else {
+            data = null;
+        }
+    }
+
+    void append(double centroid, int count, List<Double> points) {
+        if (length == means.length) {
+            // grow by 1/4
+            final int newCapacity = length + (length >>> 2);
+            means = Arrays.copyOf(means, newCapacity);
+            counts = Arrays.copyOf(counts, newCapacity);
+            if (data != null) {
+                data = Arrays.copyOf(data, newCapacity);
+            }
+        }
+        means[length] = centroid;
+        counts[length] = count;
+
+        if (data != null) {
+            if (points == null) {
+                if (count == 1) {
+                    points = Collections.singletonList(centroid);
+                } else {
+                    throw new IllegalStateException();
+                }
+            }
+            if (data[length] == null) {
+                data[length] = new ArrayList<Double>();
+            }
+            data[length].addAll(points);
+        }
+
+        length += 1;
+        totalCount += count;
+    }
+
+    long totalCount() {
+        return totalCount;
+    }
+
+    int length() {
+        return length;
+    }
+
+    double mean(int i) {
+        return means[i];
+    }
+
+    List<Double> data(int i) {
+        return data == null ? null : data[i];
+    }
+
+    int count(int i) {
+        return counts[i];
+    }
+
+    void reset() {
+        length = 0;
+        totalCount = 0;
+        if (data != null) {
+            // release memmory
+            Arrays.fill(data, null);
+        }
+    }
+
+    boolean sorted() {
+        for (int i = 0; i < length - 1; ++i) {
+            if (means[i] > means[i + 1]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void sort() {
+        quickSort(0, length, ThreadLocalRandom.current());
+    }
+
+    private void swap(int i, int j) {
+        final double tmpMean = means[i];
+        means[i] = means[j];
+        means[j] = tmpMean;
+        final int tmpCount = counts[i];
+        counts[i] = counts[j];
+        counts[j] = tmpCount;
+        if (data != null) {
+            final List<Double> tmpData = data[i];
+            data[i] = data[j];
+            data[j] = tmpData;
+        }
+    }
+
+    private void quickSort(int from, int to, Random random) {
+        if (to - from <= 1) {
+            // sorted by definition
+            return;
+        }
+        final int p = partition(from, to, random);
+        quickSort(from, p, random);
+        quickSort(p + 1, to, random);
+    }
+
+    private int partition(int from, int to, Random random) {
+        final int pivotIndex = from + random.nextInt(to - from);
+        final double pivotValue = means[pivotIndex];
+        swap(pivotIndex, to - 1);
+        int p = from;
+        for (int i = from; i < to - 1; ++i) {
+            if (means[i] < pivotValue) {
+                swap(i, p++);
+            }
+        }
+        swap(p, to - 1);
+        return p;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder().append("{ ");
+        for (int i = 0; i < length(); ++i) {
+            s.append(mean(i)).append(":").append(count(i)).append(", ");
+        }
+        if (length() > 1) {
+            s.setLength(s.length() - 2);
+        }
+        return s.append(" }").toString();
+    }
+
+    @Override
+    public Iterator<Centroid> iterator() {
+        return new Iterator<Centroid>() {
+
+            int i = 0;
+            
+            @Override
+            public boolean hasNext() {
+                return i < length;
+            }
+
+            @Override
+            public Centroid next() {
+                final Centroid next = new Centroid(mean(i), count(i));
+                final List<Double> data = data(i);
+                if (data != null) {
+                    for (Double x : data) {
+                        next.insertData(x);
+                    }
+                }
+                i += 1;
+                return next;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/src/test/java/com/tdunning/math/stats/BatchDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/BatchDigestTest.java
@@ -1,0 +1,482 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import com.clearspring.analytics.stream.quantile.QDigest;
+import com.google.common.collect.Lists;
+
+import org.apache.mahout.common.RandomUtils;
+import org.apache.mahout.math.jet.random.AbstractContinousDistribution;
+import org.apache.mahout.math.jet.random.Gamma;
+import org.apache.mahout.math.jet.random.Normal;
+import org.apache.mahout.math.jet.random.Uniform;
+import org.junit.*;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
+public class BatchDigestTest extends TDigestTest {
+
+    private DigestFactory<BatchTDigest> factory = new DigestFactory<BatchTDigest>() {
+        @Override
+        public BatchTDigest create() {
+            return new BatchTDigest(100);
+        }
+    };
+
+    @Before
+    public void testSetUp() {
+        RandomUtils.useTestSeed();
+    }
+
+    @After
+    public void flush() {
+        sizeDump.flush();
+        errorDump.flush();
+        deviationDump.flush();
+    }
+
+    @Test
+    public void testUniform() {
+        Random gen = RandomUtils.getRandom();
+        for (int i = 0; i < repeats(); i++) {
+            runTest(factory, new Uniform(0, 1, gen), 100,
+                    new double[]{0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999},
+                    "uniform", true);
+        }
+    }
+
+    @Test
+    public void testGamma() {
+        // this Gamma distribution is very heavily skewed.  The 0.1%-ile is 6.07e-30 while
+        // the median is 0.006 and the 99.9th %-ile is 33.6 while the mean is 1.
+        // this severe skew means that we have to have positional accuracy that
+        // varies by over 11 orders of magnitude.
+        Random gen = RandomUtils.getRandom();
+        for (int i = 0; i < repeats(); i++) {
+            runTest(factory, new Gamma(0.1, 0.1, gen), 100,
+//                    new double[]{6.0730483624079e-30, 6.0730483624079e-20, 6.0730483627432e-10, 5.9339110446023e-03,
+//                            2.6615455373884e+00, 1.5884778179295e+01, 3.3636770117188e+01},
+                    new double[]{0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999},
+                    "gamma", true);
+        }
+    }
+
+    @Test
+    public void testNarrowNormal() {
+        // this mixture of a uniform and normal distribution has a very narrow peak which is centered
+        // near the median.  Our system should be scale invariant and work well regardless.
+        final Random gen = RandomUtils.getRandom();
+        AbstractContinousDistribution mix = new AbstractContinousDistribution() {
+            AbstractContinousDistribution normal = new Normal(0, 1e-5, gen);
+            AbstractContinousDistribution uniform = new Uniform(-1, 1, gen);
+
+            @Override
+            public double nextDouble() {
+                double x;
+                if (gen.nextDouble() < 0.5) {
+                    x = uniform.nextDouble();
+                } else {
+                    x = normal.nextDouble();
+                }
+                return x;
+            }
+        };
+
+        for (int i = 0; i < repeats(); i++) {
+            runTest(factory, mix, 100, new double[]{0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 0.99, 0.999}, "mixture", false);
+        }
+    }
+
+    @Test
+    public void testRepeatedValues() {
+        final Random gen = RandomUtils.getRandom();
+
+        // 5% of samples will be 0 or 1.0.  10% for each of the values 0.1 through 0.9
+        AbstractContinousDistribution mix = new AbstractContinousDistribution() {
+            @Override
+            public double nextDouble() {
+                return Math.rint(gen.nextDouble() * 10) / 10.0;
+            }
+        };
+
+        BatchTDigest dist = new BatchTDigest((double) 1000);
+        List<Double> data = Lists.newArrayList();
+        for (int i1 = 0; i1 < 100000; i1++) {
+            double x = mix.nextDouble();
+            data.add(x);
+        }
+
+        long t0 = System.nanoTime();
+        for (double x : data) {
+            dist.add(x);
+        }
+
+        System.out.printf("# %fus per point\n", (System.nanoTime() - t0) * 1e-3 / 100000);
+        System.out.printf("# %d centroids\n", dist.centroids().size());
+
+        // I would be happier with 5x compression, but repeated values make things kind of weird
+        assertTrue("Summary is too large: " + dist.centroids().size(), dist.centroids().size() < 10 * (double) 1000);
+
+        // all quantiles should round to nearest actual value
+        for (int i = 0; i < 10; i++) {
+            double z = i / 10.0;
+            // we skip over troublesome points that are nearly halfway between
+            for (double delta : new double[]{0.01, 0.02, 0.03, 0.07, 0.08, 0.09}) {
+                double q = z + delta;
+                double cdf = dist.cdf(q);
+                // we also relax the tolerances for repeated values
+                assertEquals(String.format("z=%.1f, q = %.3f, cdf = %.3f", z, q, cdf), z + 0.05, cdf, 0.01);
+
+                double estimate = dist.quantile(q);
+                assertEquals(String.format("z=%.1f, q = %.3f, cdf = %.3f, estimate = %.3f", z, q, cdf, estimate), Math.rint(q * 10) / 10.0, estimate, 0.001);
+            }
+        }
+    }
+
+    @Test
+    public void testSequentialPoints() {
+        for (int i = 0; i < repeats(); i++) {
+            runTest(factory, new AbstractContinousDistribution() {
+                double base = 0;
+
+                @Override
+                public double nextDouble() {
+                    base += Math.PI * 1e-5;
+                    return base;
+                }
+            }, 100, new double[]{0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999},
+                    "sequential", true);
+        }
+    }
+
+    @Test
+    public void testSerialization() {
+        Random gen = RandomUtils.getRandom();
+        BatchTDigest dist = new BatchTDigest(100);
+        for (int i = 0; i < 100000; i++) {
+            double x = gen.nextDouble();
+            dist.add(x);
+        }
+        dist.compress();
+
+        ByteBuffer buf = ByteBuffer.allocate(20000);
+        dist.asBytes(buf);
+        assertTrue(buf.position() < 11000);
+        assertEquals(buf.position(), dist.byteSize());
+        buf.clear();
+
+        dist.asSmallBytes(buf);
+        assertTrue(buf.position() < 6000);
+        assertEquals(buf.position(), dist.smallByteSize());
+
+        System.out.printf("# big %d bytes\n", buf.position());
+
+        buf.flip();
+        BatchTDigest dist2 = BatchTDigest.fromBytes(buf);
+        assertEquals(dist.centroids().size(), dist2.centroids().size());
+        assertEquals(dist.compression(), dist2.compression(), 0);
+        assertEquals(dist.size(), dist2.size());
+
+        for (double q = 0; q < 1; q += 0.01) {
+            assertEquals(dist.quantile(q), dist2.quantile(q), 1e-8);
+        }
+
+        Iterator<? extends Centroid> ix = dist2.centroids().iterator();
+        for (Centroid centroid : dist.centroids()) {
+            assertTrue(ix.hasNext());
+            assertEquals(centroid.count(), ix.next().count());
+        }
+        assertFalse(ix.hasNext());
+
+        buf.flip();
+        dist.asSmallBytes(buf);
+        assertTrue(buf.position() < 6000);
+        System.out.printf("# small %d bytes\n", buf.position());
+
+        buf.flip();
+        dist2 = BatchTDigest.fromBytes(buf);
+        assertEquals(dist.centroids().size(), dist2.centroids().size());
+        assertEquals(dist.compression(), dist2.compression(), 0);
+        assertEquals(dist.size(), dist2.size());
+
+        for (double q = 0; q < 1; q += 0.01) {
+            assertEquals(dist.quantile(q), dist2.quantile(q), 1e-6);
+        }
+
+        ix = dist2.centroids().iterator();
+        for (Centroid centroid : dist.centroids()) {
+            assertTrue(ix.hasNext());
+            assertEquals(centroid.count(), ix.next().count());
+        }
+        assertFalse(ix.hasNext());
+    }
+
+    @Test
+    public void testIntEncoding() {
+        Random gen = RandomUtils.getRandom();
+        ByteBuffer buf = ByteBuffer.allocate(10000);
+        List<Integer> ref = Lists.newArrayList();
+        for (int i = 0; i < 3000; i++) {
+            int n = gen.nextInt();
+            n = n >>> (i / 100);
+            ref.add(n);
+            AbstractTDigest.encode(buf, n);
+        }
+
+        buf.flip();
+
+        for (int i = 0; i < 3000; i++) {
+            int n = AbstractTDigest.decode(buf);
+            assertEquals(String.format("%d:", i), ref.get(i).intValue(), n);
+        }
+    }
+
+    @Test
+    public void compareToQDigest() throws FileNotFoundException {
+        Random rand = RandomUtils.getRandom();
+        PrintWriter out = new PrintWriter(new FileOutputStream("qd-tree-comparison.csv"));
+        try {
+            for (int i = 0; i < repeats(); i++) {
+                compareQD(out, new Gamma(0.1, 0.1, rand), "gamma", 1L << 48);
+                compareQD(out, new Uniform(0, 1, rand), "uniform", 1L << 48);
+            }
+        } finally {
+            out.close();
+        }
+    }
+
+    private void compareQD(PrintWriter out, AbstractContinousDistribution gen, String tag, long scale) {
+        for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000}) {
+            QDigest qd = new QDigest(compression);
+            BatchTDigest dist = new BatchTDigest(compression);
+            List<Double> data = Lists.newArrayList();
+            for (int i = 0; i < 100000; i++) {
+                double x = gen.nextDouble();
+                dist.add(x);
+                qd.offer((long) (x * scale));
+                data.add(x);
+            }
+            dist.compress();
+            Collections.sort(data);
+
+            for (double q : new double[]{0.001, 0.01, 0.1, 0.2, 0.3, 0.5, 0.7, 0.8, 0.9, 0.99, 0.999}) {
+                double x1 = dist.quantile(q);
+                double x2 = (double) qd.getQuantile(q) / scale;
+                double e1 = cdf(x1, data) - q;
+                out.printf("%s\t%.0f\t%.8f\t%.10g\t%.10g\t%d\t%d\n", tag, compression, q, e1, cdf(x2, data) - q, dist.smallByteSize(), QDigest.serialize(qd).length);
+
+            }
+        }
+    }
+
+    @Test
+    public void compareToStreamingQuantile() throws FileNotFoundException {
+        Random rand = RandomUtils.getRandom();
+
+        PrintWriter out = new PrintWriter(new FileOutputStream("sq-tree-comparison.csv"));
+        try {
+
+            for (int i = 0; i < repeats(); i++) {
+                compareSQ(out, new Gamma(0.1, 0.1, rand), "gamma", 1L << 48);
+                compareSQ(out, new Uniform(0, 1, rand), "uniform", 1L << 48);
+            }
+        } finally {
+            out.close();
+        }
+    }
+
+    private void compareSQ(PrintWriter out, AbstractContinousDistribution gen, String tag, long scale) {
+        double[] quantiles = {0.001, 0.01, 0.1, 0.2, 0.3, 0.5, 0.7, 0.8, 0.9, 0.99, 0.999};
+        for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000}) {
+            QuantileEstimator sq = new QuantileEstimator(1001);
+            BatchTDigest dist = new BatchTDigest(compression);
+            List<Double> data = Lists.newArrayList();
+            for (int i = 0; i < 100000; i++) {
+                double x = gen.nextDouble();
+                dist.add(x);
+                sq.add(x);
+                data.add(x);
+            }
+            dist.compress();
+            Collections.sort(data);
+
+            List<Double> qz = sq.getQuantiles();
+            for (double q : quantiles) {
+                double x1 = dist.quantile(q);
+                double x2 = qz.get((int) (q * 1000 + 0.5));
+                double e1 = cdf(x1, data) - q;
+                double e2 = cdf(x2, data) - q;
+                out.printf("%s\t%.0f\t%.8f\t%.10g\t%.10g\t%d\t%d\n",
+                        tag, compression, q, e1, e2, dist.smallByteSize(), sq.serializedSize());
+
+            }
+        }
+    }
+
+    @Test()
+    public void testSizeControl() throws IOException, InterruptedException, ExecutionException {
+        // very slow running data generator.  Don't want to run this normally.  To run slow tests use
+        // mvn test -DrunSlowTests=true
+        assumeTrue(Boolean.parseBoolean(System.getProperty("runSlowTests")));
+
+        final Random gen0 = RandomUtils.getRandom();
+        final PrintWriter out = new PrintWriter(new FileOutputStream("scaling.tsv"));
+        out.printf("k\tsamples\tcompression\tsize1\tsize2\n");
+
+        List<Callable<String>> tasks = Lists.newArrayList();
+        for (int k = 0; k < 20; k++) {
+            for (final int size : new int[]{10, 100, 1000, 10000}) {
+                final int currentK = k;
+                tasks.add(new Callable<String>() {
+                    Random gen = new Random(gen0.nextLong());
+
+                    @Override
+                    public String call() throws Exception {
+                        System.out.printf("Starting %d,%d\n", currentK, size);
+                        StringWriter s = new StringWriter();
+                        PrintWriter out = new PrintWriter(s);
+                        for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000}) {
+                            BatchTDigest dist = new BatchTDigest(compression);
+                            for (int i = 0; i < size * 1000; i++) {
+                                dist.add(gen.nextDouble());
+                            }
+                            out.printf("%d\t%d\t%.0f\t%d\t%d\n", currentK, size, compression, dist.smallByteSize(), dist.byteSize());
+                            out.flush();
+                        }
+                        out.close();
+                        return s.toString();
+                    }
+                });
+            }
+        }
+
+        for (Future<String> result : Executors.newFixedThreadPool(20).invokeAll(tasks)) {
+            out.write(result.get());
+        }
+
+        out.close();
+    }
+
+    @Test
+    public void testScaling() throws FileNotFoundException, InterruptedException, ExecutionException {
+        final Random gen0 = RandomUtils.getRandom();
+
+        PrintWriter out = new PrintWriter(new FileOutputStream("error-scaling.tsv"));
+        try {
+            out.printf("pass\tcompression\tq\terror\tsize\n");
+
+            Collection<Callable<String>> tasks = Lists.newArrayList();
+            int n = Math.max(3, repeats() * repeats());
+            for (int k = 0; k < n; k++) {
+                final int currentK = k;
+                tasks.add(new Callable<String>() {
+                    Random gen = new Random(gen0.nextLong());
+
+                    @Override
+                    public String call() throws Exception {
+                        System.out.printf("Start %d\n", currentK);
+                        StringWriter s = new StringWriter();
+                        PrintWriter out = new PrintWriter(s);
+
+                        List<Double> data = Lists.newArrayList();
+                        for (int i = 0; i < 100000; i++) {
+                            data.add(gen.nextDouble());
+                        }
+                        Collections.sort(data);
+
+                        for (double compression : new double[]{2, 5, 10, 20, 50, 100, 200, 500, 1000}) {
+                            BatchTDigest dist = new BatchTDigest(compression);
+                            for (Double x : data) {
+                                dist.add(x);
+                            }
+                            dist.compress();
+
+                            for (double q : new double[]{0.001, 0.01, 0.1, 0.5}) {
+                                double estimate = dist.quantile(q);
+                                double actual = data.get((int) (q * data.size()));
+                                out.printf("%d\t%.0f\t%.3f\t%.9f\t%d\n", currentK, compression, q, estimate - actual, dist.byteSize());
+                                out.flush();
+                            }
+                        }
+                        out.close();
+                        System.out.printf("Finish %d\n", currentK);
+
+                        return s.toString();
+                    }
+                });
+            }
+
+            ExecutorService exec = Executors.newFixedThreadPool(16);
+            for (Future<String> result : exec.invokeAll(tasks)) {
+                out.write(result.get());
+            }
+        } finally {
+            out.close();
+        }
+    }
+
+    @Test
+    public void testMerge() throws FileNotFoundException, InterruptedException, ExecutionException {
+        merge(new DigestFactory<BatchTDigest>() {
+            @Override
+            public BatchTDigest create() {
+                return new BatchTDigest(50);
+            }
+        });
+    }
+
+    @Test
+    public void testEmpty() {
+        empty(new BatchTDigest(100));
+    }
+
+    @Test
+    public void testSingleValue() {
+        singleValue(new BatchTDigest(100));
+    }
+
+    @Test
+    public void testFewValues() {
+        final TDigest digest = new BatchTDigest(100);
+        fewValues(digest);
+    }
+
+    @Test
+    public void testMoreThan2BValues() {
+        final TDigest digest = new BatchTDigest(100);
+        moreThan2BValues(digest);
+    }
+
+    @Test
+    public void testSorted() {
+        final TDigest digest = factory.create();
+        sorted(digest);
+    }
+
+    @Test
+    public void testNaN() {
+        final TDigest digest = factory.create();
+        nan(digest);
+    }
+}

--- a/src/test/java/com/tdunning/math/stats/HistogramTest.java
+++ b/src/test/java/com/tdunning/math/stats/HistogramTest.java
@@ -1,0 +1,69 @@
+package com.tdunning.math.stats;
+
+import static org.junit.Assert.*;
+
+import java.util.Random;
+
+import org.junit.Test;
+
+public class HistogramTest {
+
+    @Test
+    public void testSort() {
+        for (int i = 0; i < 10; ++i) {
+            Random r = new Random(i);
+            Histogram histogram = new Histogram(false);
+            final int length = r.nextInt(10000);
+            for (int j = 0; j < length; ++j) {
+                histogram.append(r.nextDouble(), 1 + r.nextInt(5), null);
+            }
+            histogram.sort();
+            assertTrue(histogram.sorted());
+        }
+    }
+
+    @Test
+    public void testMerge() {
+        for (int i = 0; i < 10; ++i) {
+            Random r = new Random(i);
+            final int len1 = r.nextInt(10000);
+            Histogram h1 = new Histogram(false);
+            double current = 0;
+            for (int j = 0; j < len1; ++j) {
+                current += Double.MIN_VALUE + r.nextDouble();
+                h1.append(current, 1 + r.nextInt(5), null);
+            }
+            final int len2 = r.nextInt(10000);
+            Histogram h2 = new Histogram(false);
+            current = 0;
+            for (int j = 0; j < len2; ++j) {
+                current += Double.MIN_VALUE + r.nextDouble();
+                h2.append(current, 1 + r.nextInt(5), null);
+            }
+            Histogram h3 = new Histogram(false);
+            Histogram.merge(h1, h2, h3);
+            assertTrue(h3.sorted());
+            assertEquals(h3.length(), h1.length() + h2.length());
+            assertEquals(h3.totalCount(), h1.totalCount() + h2.totalCount());
+        }
+    }
+
+    @Test
+    public void testCompact() {
+        for (int i = 0; i < 10; ++i) {
+            Random r = new Random(i);
+            final int len1 = r.nextInt(10000);
+            Histogram h = new Histogram(false);
+            double current = 0;
+            for (int j = 0; j < len1; ++j) {
+                current += Double.MIN_VALUE + r.nextDouble();
+                h.append(current, 1 + r.nextInt(5), null);
+            }
+            for (int j = 0; j < 10; ++j) {
+                Histogram h2 = new Histogram(false);
+                Histogram.compact(h, h2, r.nextDouble() * 10);
+                assertEquals(h2.totalCount(), h.totalCount());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This implementation is different from the ones we already have in the sense that
it does not try to always keep a sorted histogram. Instead it maintains a buffer
and a main histogram and periodically merges the buffer into the histogram.

Tests pass but I think it's still required to check this impl for correctness
given how different it is from the other impls (feedback is highly welcome!).

Although it would not be a good fit if you need to evalutate quantiles
periodically (every time that you do so, it needs to merge the buffer into the
main histogram), it seems to perform much faster (about 2x with a uniform
distribution, see output of the t-digest jmh benchmark below) for the 'batch'
case when you first add all your values and then evaluate quantiles.
![results](https://cloud.githubusercontent.com/assets/299848/5541926/3ba0aed8-8ae0-11e4-914e-d4912564ce42.png)

Another good property is that it is much less subject to worst-cases such as
sequential values, I got more than 10x speed-ups in those cases.