### PR TITLE
Remove AbstractTDigest.compress(GroupTree).

### DIFF
--- a/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
@@ -166,11 +166,6 @@ public class AVLTreeDigest extends AbstractTDigest {
         }
     }
 
-    @Override
-    public void compress(GroupTree other) {
-        throw new UnsupportedOperationException();
-    }
-
     /**
      * Returns the number of samples represented in this histogram.  If you want to know how many
      * centroids are being used, try centroids().size().

--- a/src/main/java/com/tdunning/math/stats/AbstractTDigest.java
+++ b/src/main/java/com/tdunning/math/stats/AbstractTDigest.java
@@ -85,8 +85,6 @@ public abstract class AbstractTDigest extends TDigest {
         return r;
     }
 
-    public abstract void compress(GroupTree other);
-
     static double quantile(double previousIndex, double index, double nextIndex, double previousMean, double nextMean) {
         final double delta = nextIndex - previousIndex;
         final double previousWeight = (nextIndex - index) / delta;

--- a/src/main/java/com/tdunning/math/stats/ArrayDigest.java
+++ b/src/main/java/com/tdunning/math/stats/ArrayDigest.java
@@ -221,11 +221,6 @@ public class ArrayDigest extends AbstractTDigest {
     }
 
     @Override
-    public void compress(GroupTree other) {
-        throw new UnsupportedOperationException("Default operation");
-    }
-
-    @Override
     public long size() {
         return totalWeight;
     }

--- a/src/main/java/com/tdunning/math/stats/TreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/TreeDigest.java
@@ -148,17 +148,12 @@ public class TreeDigest extends AbstractTDigest {
 
     @Override
     public void compress() {
-        compress(summary);
-    }
-
-    @Override
-    public void compress(GroupTree other) {
         TreeDigest reduced = new TreeDigest(compression);
         if (recordAllData) {
             reduced.recordAllData();
         }
         List<Centroid> tmp = new ArrayList<Centroid>();
-        for (Centroid centroid : other) {
+        for (Centroid centroid : summary) {
             tmp.add(centroid);
         }
         Collections.shuffle(tmp, gen);


### PR DESCRIPTION
This method is only used as a helper method on the TreeDigest impl, and both
ArrayDigest and AVLTreeDigest throw an UnsupportedOperationException when it
is called.
