### PR TITLE
Remove TDigest.centroidCount() and make centroids() return a Collection instead of an Iterable.

### DIFF
--- a/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
+++ b/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
@@ -17,6 +17,7 @@
 
 package com.tdunning.math.stats;
 
+import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -25,7 +26,7 @@ import java.util.List;
 /**
  * A tree of t-digest centroids.
  */
-final class AVLGroupTree implements Iterable<Centroid> {
+final class AVLGroupTree extends AbstractCollection<Centroid> {
 
     /* For insertions into the tree */
     private double centroid;
@@ -153,8 +154,10 @@ final class AVLGroupTree implements Iterable<Centroid> {
         tree.add();
     }
 
-    public void add(Centroid centroid) {
+    @Override
+    public boolean add(Centroid centroid) {
         add(centroid.mean(), centroid.count(), centroid.data());
+        return true;
     }
 
     /**

--- a/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
@@ -18,6 +18,8 @@
 package com.tdunning.math.stats;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -295,13 +297,8 @@ public class AVLTreeDigest extends AbstractTDigest {
     }
 
     @Override
-    public int centroidCount() {
-        return summary.size();
-    }
-
-    @Override
-    public Iterable<? extends Centroid> centroids() {
-        return summary;
+    public Collection<Centroid> centroids() {
+        return Collections.unmodifiableCollection(summary);
     }
 
     @Override

--- a/src/main/java/com/tdunning/math/stats/ArrayDigest.java
+++ b/src/main/java/com/tdunning/math/stats/ArrayDigest.java
@@ -18,7 +18,9 @@
 package com.tdunning.math.stats;
 
 import java.nio.ByteBuffer;
+import java.util.AbstractCollection;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -172,25 +174,6 @@ public class ArrayDigest extends AbstractTDigest {
         return r;
     }
 
-    /**
-     * Returns the number of centroids strictly before the limit.
-     */
-    private int headCount(Index limit) {
-        int r = 0;
-
-        for (int i = 0; i < limit.page; i++) {
-            r += data.get(i).active;
-        }
-
-        if (limit.page < data.size()) {
-            for (int j = 0; j < limit.subPage; j++) {
-                r++;
-            }
-        }
-
-        return r;
-    }
-
     public double mean(Index index) {
         return data.get(index.page).centroids[index.subPage];
     }
@@ -281,9 +264,9 @@ public class ArrayDigest extends AbstractTDigest {
             throw new IllegalArgumentException("q should be in [0,1], got " + q);
         }
 
-        if (centroidCount() == 0) {
+        if (centroidCount == 0) {
             return Double.NaN;
-        } else if (centroidCount() == 1) {
+        } else if (centroidCount == 1) {
             return data.get(0).centroids[0];
         }
 
@@ -344,26 +327,44 @@ public class ArrayDigest extends AbstractTDigest {
     }
 
     @Override
-    public int centroidCount() {
-        return centroidCount;
-    }
+    public Collection<Centroid> centroids() {
+        return new AbstractCollection<Centroid>() {
 
-    @Override
-    public Iterable<? extends Centroid> centroids() {
-        List<Centroid> r = new ArrayList<Centroid>();
-        Iterator<Index> ix = iterator(0, 0);
-        while (ix.hasNext()) {
-            Index index = ix.next();
-            Page current = data.get(index.page);
-            Centroid centroid = new Centroid(current.centroids[index.subPage], current.counts[index.subPage]);
-            if (current.history != null) {
-                for (double x : current.history.get(index.subPage)) {
-                    centroid.insertData(x);
-                }
+            @Override
+            public Iterator<Centroid> iterator() {
+                final Iterator<Index> ix = ArrayDigest.this.iterator(0, 0);
+                return new Iterator<Centroid>() {
+
+                    @Override
+                    public boolean hasNext() {
+                        return ix.hasNext();
+                    }
+
+                    @Override
+                    public Centroid next() {
+                        final Index index = ix.next();
+                        final Page current = data.get(index.page);
+                        Centroid centroid = new Centroid(current.centroids[index.subPage], current.counts[index.subPage]);
+                        if (current.history != null) {
+                            for (double x : current.history.get(index.subPage)) {
+                                centroid.insertData(x);
+                            }
+                        }
+                        return centroid;
+                    }
+
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
             }
-            r.add(centroid);
-        }
-        return r;
+
+            @Override
+            public int size() {
+                return centroidCount;
+            }
+        };
     }
 
     public Iterator<Index> allAfter(double x) {

--- a/src/main/java/com/tdunning/math/stats/GroupTree.java
+++ b/src/main/java/com/tdunning/math/stats/GroupTree.java
@@ -17,6 +17,7 @@
 
 package com.tdunning.math.stats;
 
+import java.util.AbstractCollection;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
@@ -26,7 +27,7 @@ import java.util.NoSuchElementException;
  * A tree containing TDigest.Centroid.  This adds to the normal NavigableSet the
  * ability to sum up the size of elements to the left of a particular group.
  */
-public class GroupTree implements Iterable<Centroid> {
+public class GroupTree extends AbstractCollection<Centroid> {
     private long count;
     private int size;
     private int depth;
@@ -55,13 +56,13 @@ public class GroupTree implements Iterable<Centroid> {
         leaf = this.right.first();
     }
 
-    public void add(Centroid centroid) {
+    public boolean add(Centroid centroid) {
         if (size == 0) {
             leaf = centroid;
             depth = 1;
             count = centroid.count();
             size = 1;
-            return;
+            return true;
         } else if (size == 1) {
             int order = centroid.compareTo(leaf);
             if (order < 0) {
@@ -82,6 +83,7 @@ public class GroupTree implements Iterable<Centroid> {
         depth = Math.max(left.depth, right.depth) + 1;
 
         rebalance();
+        return true;
     }
 
     /**

--- a/src/main/java/com/tdunning/math/stats/TDigest.java
+++ b/src/main/java/com/tdunning/math/stats/TDigest.java
@@ -18,6 +18,7 @@
 package com.tdunning.math.stats;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
 
 /**
  * Adaptive histogram based on something like streaming k-means crossed with Q-digest.
@@ -144,19 +145,12 @@ public abstract class TDigest {
     public abstract double quantile(double q);
 
     /**
-     * The number of centroids currently in the TDigest.
-     *
-     * @return The number of centroids
-     */
-    public abstract int centroidCount();
-
-    /**
-     * An iterable that lets you go through the centroids in ascending order by mean.  Centroids
+     * A {@link Collection} that lets you go through the centroids in ascending order by mean.  Centroids
      * returned will not be re-used, but may or may not share storage with this TDigest.
      *
-     * @return The centroids in the form of an Iterable.
+     * @return The centroids in the form of a Collection.
      */
-    public abstract Iterable<? extends Centroid> centroids();
+    public abstract Collection<Centroid> centroids();
 
     /**
      * Returns the current compression factor.

--- a/src/main/java/com/tdunning/math/stats/TreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/TreeDigest.java
@@ -19,6 +19,7 @@ package com.tdunning.math.stats;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -286,13 +287,8 @@ public class TreeDigest extends AbstractTDigest {
     }
 
     @Override
-    public int centroidCount() {
-        return summary.size();
-    }
-
-    @Override
-    public Iterable<? extends Centroid> centroids() {
-        return summary;
+    public Collection<Centroid> centroids() {
+        return Collections.unmodifiableCollection(summary);
     }
 
     @Override

--- a/src/test/java/com/tdunning/math/stats/AVLTreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/AVLTreeDigestTest.java
@@ -133,10 +133,10 @@ public class AVLTreeDigestTest extends TDigestTest {
         }
 
         System.out.printf("# %fus per point\n", (System.nanoTime() - t0) * 1e-3 / 100000);
-        System.out.printf("# %d centroids\n", dist.centroidCount());
+        System.out.printf("# %d centroids\n", dist.centroids().size());
 
         // I would be happier with 5x compression, but repeated values make things kind of weird
-        assertTrue("Summary is too large: " + dist.centroidCount(), dist.centroidCount() < 10 * (double) 1000);
+        assertTrue("Summary is too large: " + dist.centroids().size(), dist.centroids().size() < 10 * (double) 1000);
 
         // all quantiles should round to nearest actual value
         for (int i = 0; i < 10; i++) {
@@ -194,7 +194,7 @@ public class AVLTreeDigestTest extends TDigestTest {
 
         buf.flip();
         AVLTreeDigest dist2 = AVLTreeDigest.fromBytes(buf);
-        assertEquals(dist.centroidCount(), dist2.centroidCount());
+        assertEquals(dist.centroids().size(), dist2.centroids().size());
         assertEquals(dist.compression(), dist2.compression(), 0);
         assertEquals(dist.size(), dist2.size());
 
@@ -216,7 +216,7 @@ public class AVLTreeDigestTest extends TDigestTest {
 
         buf.flip();
         dist2 = AVLTreeDigest.fromBytes(buf);
-        assertEquals(dist.centroidCount(), dist2.centroidCount());
+        assertEquals(dist.centroids().size(), dist2.centroids().size());
         assertEquals(dist.compression(), dist2.compression(), 0);
         assertEquals(dist.size(), dist2.size());
 
@@ -474,13 +474,9 @@ public class AVLTreeDigestTest extends TDigestTest {
         // answer to extreme quantiles in that case ('extreme' in the sense that the
         // quantile is either before the first node or after the last one)
         AVLTreeDigest digest = new AVLTreeDigest(100);
-        // we need to create the GroupTree manually
-        AVLGroupTree tree = (AVLGroupTree) digest.centroids();
-        Centroid g = new Centroid(10);
-        tree.add(10, 3, null);
-        tree.add(20, 1, null);
-        tree.add(40, 5, null);
-        digest.count = 3 + 1 + 5;
+        digest.add(10, 3);
+        digest.add(20, 1);
+        digest.add(40, 5);
         // this group tree is roughly equivalent to the following sorted array:
         // [ ?, 10, ?, 20, ?, ?, 50, ?, ? ]
         // and we expect it to compute approximate missing values:

--- a/src/test/java/com/tdunning/math/stats/ArrayDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/ArrayDigestTest.java
@@ -120,7 +120,7 @@ public class ArrayDigestTest extends TDigestTest {
         }
 
         assertEquals(totalWeight, ad.size());
-        assertEquals(1001, ad.centroidCount());
+        assertEquals(1001, ad.centroids().size());
 
         for (int i = 0; i < 1000; i++) {
             int w = random.nextInt(5) + 2;
@@ -131,7 +131,7 @@ public class ArrayDigestTest extends TDigestTest {
         }
 
         assertEquals(totalWeight, ad.size());
-        assertEquals(2001, ad.centroidCount());
+        assertEquals(2001, ad.centroids().size());
 
 
         Collections.sort(ref);
@@ -145,10 +145,10 @@ public class ArrayDigestTest extends TDigestTest {
         }
 
         assertEquals(0, Lists.newArrayList(ad.allBefore(0)).size());
-        assertEquals(ad.centroidCount(), Lists.newArrayList(ad.allBefore(1)).size());
+        assertEquals(ad.centroids().size(), Lists.newArrayList(ad.allBefore(1)).size());
 
         assertEquals(0, Lists.newArrayList(ad.allAfter(1)).size());
-        assertEquals(ad.centroidCount(), Lists.newArrayList(ad.allAfter(0)).size());
+        assertEquals(ad.centroids().size(), Lists.newArrayList(ad.allAfter(0)).size());
 
         for (int k = 0; k < 1000; k++) {
             final double split = random.nextDouble();
@@ -166,7 +166,7 @@ public class ArrayDigestTest extends TDigestTest {
                 i++;
             }
 
-            assertEquals("Bad counts for split " + split, ad.centroidCount(), z1.size() + z2.size());
+            assertEquals("Bad counts for split " + split, ad.centroids().size(), z1.size() + z2.size());
         }
     }
 
@@ -289,10 +289,10 @@ public class ArrayDigestTest extends TDigestTest {
             dist.compress();
 
             System.out.printf("# %fus per point\n", (System.nanoTime() - t0) * 1e-3 / 100000);
-            System.out.printf("# %d centroids\n", dist.centroidCount());
+            System.out.printf("# %d centroids\n", dist.centroids().size());
 
             // I would be happier with 5x compression, but repeated values make things kind of weird
-            assertTrue(String.format("Summary is too large, got %d, wanted < %.1f", dist.centroidCount(), 10 * 1000.0), dist.centroidCount() < 10 * (double) 1000);
+            assertTrue(String.format("Summary is too large, got %d, wanted < %.1f", dist.centroids().size(), 10 * 1000.0), dist.centroids().size() < 10 * (double) 1000);
 
             // all quantiles should round to nearest actual value
             for (int i = 0; i < 10; i++) {
@@ -344,7 +344,7 @@ public class ArrayDigestTest extends TDigestTest {
 
         buf.flip();
         TDigest dist2 = ArrayDigest.fromBytes(buf);
-        assertEquals(dist.centroidCount(), dist2.centroidCount());
+        assertEquals(dist.centroids().size(), dist2.centroids().size());
         assertEquals(dist.compression(), dist2.compression(), 0);
         assertEquals(dist.size(), dist2.size());
 
@@ -358,7 +358,7 @@ public class ArrayDigestTest extends TDigestTest {
 
         buf.flip();
         TDigest dist3 = ArrayDigest.fromBytes(buf);
-        assertEquals(dist.centroidCount(), dist3.centroidCount());
+        assertEquals(dist.centroids().size(), dist3.centroids().size());
         assertEquals(dist.compression(), dist3.compression(), 0);
         assertEquals(dist.size(), dist3.size());
 
@@ -380,7 +380,7 @@ public class ArrayDigestTest extends TDigestTest {
 
         buf.flip();
         dist3 = ArrayDigest.fromBytes(buf);
-        assertEquals(dist.centroidCount(), dist3.centroidCount());
+        assertEquals(dist.centroids().size(), dist3.centroids().size());
         assertEquals(dist.compression(), dist3.compression(), 0);
         assertEquals(dist.size(), dist3.size());
 

--- a/src/test/java/com/tdunning/math/stats/TDigestMemoryBenchmark.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestMemoryBenchmark.java
@@ -26,7 +26,7 @@ public class TDigestMemoryBenchmark {
 
     private static double memoryUsagePerCentroid(TDigest tdigest) {
         final long totalSize = RamUsageEstimator.sizeOf(tdigest);
-        return (double) totalSize / tdigest.centroidCount();
+        return (double) totalSize / tdigest.centroids().size();
     }
 
 }

--- a/src/test/java/com/tdunning/math/stats/TDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestTest.java
@@ -205,7 +205,7 @@ public class TDigestTest {
         Collections.sort(values);
 
         // for this value of the compression, the tree shouldn't have merged any node
-        assertEquals(digest.centroidCount(), values.size());
+        assertEquals(digest.centroids().size(), values.size());
         for (double q : new double [] {0, 1e-10, r.nextDouble(), 0.5, 1-1e-10, 1}) {
             assertEquals(quantile(q, values), digest.quantile(q), 0.01);
         }
@@ -267,7 +267,7 @@ public class TDigestTest {
         }
         dist.compress();
         System.out.printf("# %fus per point\n", (System.nanoTime() - t0) * 1e-3 / 100000);
-        System.out.printf("# %d centroids\n", dist.centroidCount());
+        System.out.printf("# %d centroids\n", dist.centroids().size());
         Collections.sort(data);
 
         double[] xValues = qValues.clone();
@@ -287,9 +287,9 @@ public class TDigestTest {
             iz++;
         }
         assertEquals(qz, dist.size(), 1e-10);
-        assertEquals(iz, dist.centroidCount());
+        assertEquals(iz, dist.centroids().size());
 
-        assertTrue(String.format("Summary is too large (got %d, wanted < %.1f)", dist.centroidCount(), 11 * sizeGuide), dist.centroidCount() < 11 * sizeGuide);
+        assertTrue(String.format("Summary is too large (got %d, wanted < %.1f)", dist.centroids().size(), 11 * sizeGuide), dist.centroids().size() < 11 * sizeGuide);
         int softErrors = 0;
         for (int i = 0; i < xValues.length; i++) {
             double x = xValues[i];

--- a/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
@@ -133,10 +133,10 @@ public class TreeDigestTest extends TDigestTest {
         }
 
         System.out.printf("# %fus per point\n", (System.nanoTime() - t0) * 1e-3 / 100000);
-        System.out.printf("# %d centroids\n", dist.centroidCount());
+        System.out.printf("# %d centroids\n", dist.centroids().size());
 
         // I would be happier with 5x compression, but repeated values make things kind of weird
-        assertTrue("Summary is too large", dist.centroidCount() < 10 * (double) 1000);
+        assertTrue("Summary is too large", dist.centroids().size() < 10 * (double) 1000);
 
         // all quantiles should round to nearest actual value
         for (int i = 0; i < 10; i++) {
@@ -194,7 +194,7 @@ public class TreeDigestTest extends TDigestTest {
 
         buf.flip();
         TreeDigest dist2 = TreeDigest.fromBytes(buf);
-        assertEquals(dist.centroidCount(), dist2.centroidCount());
+        assertEquals(dist.centroids().size(), dist2.centroids().size());
         assertEquals(dist.compression(), dist2.compression(), 0);
         assertEquals(dist.size(), dist2.size());
 
@@ -216,7 +216,7 @@ public class TreeDigestTest extends TDigestTest {
 
         buf.flip();
         dist2 = TreeDigest.fromBytes(buf);
-        assertEquals(dist.centroidCount(), dist2.centroidCount());
+        assertEquals(dist.centroids().size(), dist2.centroids().size());
         assertEquals(dist.compression(), dist2.compression(), 0);
         assertEquals(dist.size(), dist2.size());
 
@@ -474,17 +474,9 @@ public class TreeDigestTest extends TDigestTest {
         // answer to extreme quantiles in that case ('extreme' in the sense that the
         // quantile is either before the first node or after the last one)
         TreeDigest digest = new TreeDigest(100);
-        // we need to create the GroupTree manually
-        GroupTree tree = (GroupTree) digest.centroids();
-        Centroid g = new Centroid(10);
-        g.add(10, 2); // 10 has a weight of 3 (1+2)
-        tree.add(g);
-        g = new Centroid(20); // 20 has a weight of 1
-        tree.add(g);
-        g = new Centroid(40);
-        g.add(40, 4); // 40 has a weight of 5 (1+4)
-        tree.add(g);
-        digest.count = 3 + 1 + 5;
+        digest.add(10, 3);
+        digest.add(20, 1);
+        digest.add(40, 5);
         // this group tree is roughly equivalent to the following sorted array:
         // [ ?, 10, ?, 20, ?, ?, 50, ?, ? ]
         // and we expect it to compute approximate missing values:


### PR DESCRIPTION
Today we have TDigest.centroids() which returns an iterable and
TDigest.centroidCount() which returns the number of centroids. This is exactly
what a java Collection is: an Iterable whose size is known. So from a usability
perspective I think it'd be more convenient to remove centroidCount() and make
centroids() return a List. This way, TDigest can be used with all methods that
take a Collection but not an Iterable (eg. List.addAll).

The only downside is that now you need to create an object in order to have
access to the number of centroids, but this is something that escape analysis
should easility remove. So I think it's worth exposing this information through
the Collection interface in order to have a nicer API.
