### PR TITLE
Fix accuracy issues caused by floating-point rounding errors.

### DIFF
--- a/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
@@ -126,8 +126,8 @@ public class AVLTreeDigest extends AbstractTDigest {
                         d.addAll(data);
                     }
                 }
+                centroid = weightedAverage(centroid, count, x, w);
                 count += w;
-                centroid += w * (x - centroid) / count;
                 summary.update(closest, centroid, count, d);
             }
             count += w;

--- a/src/main/java/com/tdunning/math/stats/AbstractTDigest.java
+++ b/src/main/java/com/tdunning/math/stats/AbstractTDigest.java
@@ -27,6 +27,32 @@ public abstract class AbstractTDigest extends TDigest {
     protected Random gen = new Random();
     protected boolean recordAllData = false;
 
+    /**
+     * Same as {@link #weightedAverageSorted(double, int, double, int)} but flips
+     * the order of the variables if <code>x2</code> is greater than
+     * <code>x1</code>.
+     */
+    public static double weightedAverage(double x1, int w1, double x2, int w2) {
+        if (x1 <= x2) {
+            return weightedAverageSorted(x1, w1, x2, w2);
+        } else {
+            return weightedAverageSorted(x2, w2, x1, w1);
+        }
+    }
+
+    /**
+     * Compute the weighted average between <code>x1</code> with a weight of
+     * <code>w1</code> and <code>x2</code> with a weight of <code>w2</code>.
+     * This expects <code>x1</code> to be less than or equal to <code>x2</code>
+     * and is guaranteed to return a number between <code>x1</code> and
+     * <code>x2</code>.
+     */
+    public static double weightedAverageSorted(double x1, int w1, double x2, int w2) {
+        assert x1 <= x2;
+        final double x = (x1 * w1 + x2 * w2) / (w1 + w2);
+        return Math.max(x1, Math.min(x, x2));
+    }
+
     public static double interpolate(double x, double x0, double x1) {
         return (x - x0) / (x1 - x0);
     }

--- a/src/main/java/com/tdunning/math/stats/Centroid.java
+++ b/src/main/java/com/tdunning/math/stats/Centroid.java
@@ -134,7 +134,7 @@ public class Centroid implements Comparable<Centroid> {
                 actualData.add(x);
             }
         }
+        centroid = AbstractTDigest.weightedAverage(centroid, count, x, w);
         count += w;
-        centroid += w * (x - centroid) / count;
     }
 }


### PR DESCRIPTION
t-digests rely on the assumption that the average between x1 and x2 is
necessarily between x1 and x2 given that their weights are positive. This is
unfortunately not the case if x1 and x2 are close enough and the computation of
the average results in a loss of accuracy. ArrayDigest was particularly prone
to this issue given that on a given page, it sequentially searches for the
first centroid that is greater than or equal to the value to add, so on each
page, floating-point rounding errors can propagate to the left.

Here is the generated error.pdf without the fix
![error](https://cloud.githubusercontent.com/assets/299848/5579673/dd7cb522-903e-11e4-90d3-85ba5f758774.png)

And now with the fix applied
![error](https://cloud.githubusercontent.com/assets/299848/5579681/f53788a4-903e-11e4-9fa2-4c709f29ad29.png)

Close #25
