### PR TITLE
Prevent Centroid ID collisions

### DIFF
--- a/src/main/java/com/tdunning/math/stats/Centroid.java
+++ b/src/main/java/com/tdunning/math/stats/Centroid.java
@@ -27,14 +27,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class Centroid implements Comparable<Centroid> {
     private static final AtomicInteger uniqueCount = new AtomicInteger(1);
 
+    // Generate a random base for the ID. This will (with high probability) prevent collisions
+    // in the event of Centroids from two different JVM instances being merged (e.g. in a
+    // distributed system or across serialization/deserialization).
+    private static final long ID_BASE = ((long) new java.util.Random().nextInt()) << 32;
+
     private double centroid = 0;
     private int count = 0;
-    private int id;
+    private long id;
 
     private List<Double> actualData = null;
 
     Centroid(boolean record) {
-        id = uniqueCount.getAndIncrement();
+        id = ID_BASE + uniqueCount.getAndIncrement();
         if (record) {
             actualData = new ArrayList<Double>();
         }
@@ -61,7 +66,7 @@ public class Centroid implements Comparable<Centroid> {
     }
 
     private void start(double x, int w, int id) {
-        this.id = id;
+        this.id = ID_BASE + id;
         add(x, w);
     }
 
@@ -82,7 +87,7 @@ public class Centroid implements Comparable<Centroid> {
     }
 
     public int id() {
-        return id;
+        return ((int) (id & 0xFFFFFFFFL));
     }
 
     @Override
@@ -95,14 +100,21 @@ public class Centroid implements Comparable<Centroid> {
 
     @Override
     public int hashCode() {
-        return id;
+        return id();
     }
 
     @Override
     public int compareTo(Centroid o) {
         int r = Double.compare(centroid, o.centroid);
         if (r == 0) {
-            r = id - o.id;
+            long idDiff = id - o.id;
+            if (idDiff < 0L) {
+                r = -1;
+            } else if (idDiff > 0L) {
+                r = 1;
+            } else {
+                r = 0;
+            }
         }
         return r;
     }


### PR DESCRIPTION
In a distributed system (or other environment consisting of multiple JVM instances) it is possible
for the current Centroid code to generate duplicate IDs. This breaks compareTo because the ID is
used as a tie-breaker. This commit changes the ID from an `int` to a `long`, and uses the high bits
to store a "JVM ID". This should make collisions statistically infeasible (one in 4 billion for a
given pair of JVMs).