### PR TITLE
Fix CDF calculation

### DIFF
--- a/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
+++ b/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
@@ -205,26 +205,28 @@ public class AVLTreeDigest extends AbstractTDigest {
             double right = left;
 
             // scan to next to last element
-            while (it.hasNext()) {
+            while (true) {
                 if (x < a.mean() + right) {
-                    return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+                    double value = (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+                    return value > 0.0 ? value : 0.0;
                 }
+
                 r += a.count();
-
+                
                 a = b;
-                b = it.next();
-
                 left = right;
-                right = (b.mean() - a.mean()) / 2;
-            }
-
-            // for the last element, assume right width is same as left
-            left = right;
-            a = b;
-            if (x < a.mean() + right) {
-                return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
-            } else {
-                return 1;
+                
+                if(it.hasNext()) {
+                    b = it.next();
+                    right = (b.mean() - a.mean()) / 2;
+                } else {
+                    // for the last element, assume right width is same as left
+                    if (x < a.mean() + right) {
+                        return (r + a.count() * interpolate(x, a.mean() - left, a.mean() + right)) / count;
+                    } else {
+                        return 1;
+                    }
+                }
             }
         }
     }

--- a/src/test/java/com/tdunning/math/stats/AVLTreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/AVLTreeDigestTest.java
@@ -522,6 +522,28 @@ public class AVLTreeDigestTest extends TDigestTest {
     }
 
     @Test
+    public void testCDFNonDecreasing() {
+        AVLTreeDigest digest = new AVLTreeDigest(100);
+
+        digest.add(25., 1);
+        digest.add(14., 1);
+        digest.add(10., 1);
+        digest.add(13., 1);
+        digest.add( 5., 1);
+        digest.add(20., 1);
+        digest.add(27., 1);
+        digest.compress();
+
+        double max = 0.;
+        for(int num = 0; num < 30; ++num) {
+            double cdf = digest.cdf((double)num);
+            System.out.printf("# cdf (%d) = %.3f\n", num, cdf);
+            assertTrue(max <= cdf);
+            max = cdf;
+        }
+    }
+
+    @Test
     public void testSorted() {
         final TDigest digest = factory.create();
         sorted(digest);


### PR DESCRIPTION
Don't skip the last interval and use proper linear function for (n-1)th interval. Currently it skips check (x < a.mean() + right) for the last interval and uses nth linear function for (n-1)th interval which may result in dips in CDF. 