### PR TITLE
Speed up merge digest algorithm by using a function that approximates arcsin

### DIFF
--- a/src/main/java/com/tdunning/math/stats/MergingDigest.java
+++ b/src/main/java/com/tdunning/math/stats/MergingDigest.java
@@ -357,7 +357,22 @@ public class MergingDigest extends AbstractTDigest {
      * @return The centroid scale value corresponding to q.
      */
     private double integratedLocation(double q) {
-        return compression * (Math.asin(2 * q - 1) + Math.PI / 2) / Math.PI;
+        return compression * (approximateSteeperArcSin(2 * q - 1) + Math.PI / 2) / Math.PI;
+    }
+
+    /**
+     * A function that approximates arcsin. Its derivative is always steeper than the derivative of arcsin.
+     * <p>
+     * see <a href="http://www.wolframalpha.com/input/?i=minimize+%28d%2Fdx%28%282-x%2F2+%2B+5+x^2%2F24%29*%281-sqrt%281-x%29%29+-+arcsin%28x%29%29%29+over+[0%2C1]">difference of 1st derivative</a>
+     * <p>
+     * the maximum relative approximation error is at x=1,
+     * see <a href="http://www.wolframalpha.com/input/?i=plot+%28%28%282-x%2F2+%2B+5+x^2%2F24%29*%281-sqrt%281-x%29%29%2Farcsin%28x%29%29%29+x+in+[0%2C1]">maximum relative error</a>
+     * <p>
+     * approximateSteeperArcusSin(1) = 1.08756 * pi/2
+     */
+    static double approximateSteeperArcSin(double x) {
+    	double absX = Math.abs(x);
+    	return Math.copySign((2.-absX*(0.5 - (5d/24d)*absX))*(1d-Math.sqrt(1d-absX)), x);
     }
 
     @Override

--- a/src/test/java/com/tdunning/math/stats/MergingDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/MergingDigestTest.java
@@ -568,4 +568,47 @@ public class MergingDigestTest extends TDigestTest {
         final TDigest digest = factory.create();
         nan(digest);
     }
+
+    @Test
+    public void testApproximateSteeperArcSin() {
+    	int numTrials = 100000;
+    	Random random = new Random(0L);
+    	for (int i = 0; i < numTrials; ++i) {
+    		double a = 2*random.nextDouble()-1.;
+    		double b = 2*random.nextDouble()-1.;
+    		if (b < a) {
+    			double c = a;
+    			a = b;
+    			b = c;
+    		}
+    		assertTrue(Math.asin(b) - Math.asin(a) <= MergingDigest.approximateSteeperArcSin(b) - MergingDigest.approximateSteeperArcSin(a));
+    	}
+    }
+
+    @Test
+    public void testPerformanceArcSin() {
+    	int N = 100000000;
+    	double sum = 0.;
+    	long start = System.currentTimeMillis();
+    	for (int i = 0; i < N; ++i) {
+    		sum += Math.asin(((double)i)/N);
+    	}
+    	long end = System.currentTimeMillis();
+    	System.out.println("dummyResult = " + sum);
+    	System.out.println("Avg. computation time = " + (1e6*(end-start))/N + "ns");
+    }
+
+    @Test
+    public void testPerformanceApproximateSteeperArcSin() {
+    	int N = 100000000;
+    	double sum = 0.;
+    	long start = System.currentTimeMillis();
+    	for (int i = 0; i < N; ++i) {
+    		sum += MergingDigest.approximateSteeperArcSin(((double)i)/N);
+    	}
+    	long end = System.currentTimeMillis();
+    	System.out.println("dummyResult = " + sum);
+    	System.out.println("Avg. computation time = " + (1e6*(end-start))/N + "ns");
+    }
+
 }


### PR DESCRIPTION
The arcsin evaluation is limitting the performance of the merge digest algorithm. An arcsin evaluation takes more than 200ns on my machine. I have introduced an example of an approximating function to arcsin that is much cheaper to evaluate (approx. 15ns) and that is always steeper than arcsin, therefore replacing arcsin by this function gives at least as accurate results, however as trade-off slightly more (approx. +8%) centroids are used.
