### PR TITLE
Make various TDigests serializable (e.g. for use with Spark).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
             <version>0.0.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
+++ b/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
@@ -17,6 +17,7 @@
 
 package com.tdunning.math.stats;
 
+import java.io.Serializable;
 import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,7 +27,7 @@ import java.util.List;
 /**
  * A tree of t-digest centroids.
  */
-final class AVLGroupTree extends AbstractCollection<Centroid> {
+final class AVLGroupTree extends AbstractCollection<Centroid> implements Serializable {
 
     /* For insertions into the tree */
     private double centroid;

--- a/src/main/java/com/tdunning/math/stats/ArrayDigest.java
+++ b/src/main/java/com/tdunning/math/stats/ArrayDigest.java
@@ -17,6 +17,7 @@
 
 package com.tdunning.math.stats;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.AbstractCollection;
 import java.util.ArrayList;
@@ -755,7 +756,7 @@ public class ArrayDigest extends AbstractTDigest {
     public final static int VERBOSE_ARRAY_DIGEST = 3;
     public final static int SMALL_ARRAY_DIGEST = 4;
 
-    class Index {
+    class Index implements Serializable {
         final int page, subPage;
 
         private Index(int page, int subPage) {
@@ -772,7 +773,7 @@ public class ArrayDigest extends AbstractTDigest {
         }
     }
 
-    private static class Page {
+    private static class Page implements Serializable {
         private final boolean recordAllData;
         private final int pageSize;
 

--- a/src/main/java/com/tdunning/math/stats/Centroid.java
+++ b/src/main/java/com/tdunning/math/stats/Centroid.java
@@ -17,6 +17,7 @@
 
 package com.tdunning.math.stats;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -24,7 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * A single centroid which represents a number of data points.
  */
-public class Centroid implements Comparable<Centroid> {
+public class Centroid implements Comparable<Centroid>, Serializable {
     private static final AtomicInteger uniqueCount = new AtomicInteger(1);
 
     private double centroid = 0;

--- a/src/main/java/com/tdunning/math/stats/GroupTree.java
+++ b/src/main/java/com/tdunning/math/stats/GroupTree.java
@@ -17,6 +17,7 @@
 
 package com.tdunning.math.stats;
 
+import java.io.Serializable;
 import java.util.AbstractCollection;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -27,7 +28,7 @@ import java.util.NoSuchElementException;
  * A tree containing TDigest.Centroid.  This adds to the normal NavigableSet the
  * ability to sum up the size of elements to the left of a particular group.
  */
-public class GroupTree extends AbstractCollection<Centroid> {
+public class GroupTree extends AbstractCollection<Centroid> implements Serializable {
     private long count;
     private int size;
     private int depth;

--- a/src/main/java/com/tdunning/math/stats/IntAVLTree.java
+++ b/src/main/java/com/tdunning/math/stats/IntAVLTree.java
@@ -1,5 +1,6 @@
 package com.tdunning.math.stats;
 
+import java.io.Serializable;
 import java.util.Arrays;
 
 
@@ -9,7 +10,7 @@ import java.util.Arrays;
  * want to add data to the nodes, typically by using arrays and node
  * identifiers as indices.
  */
-abstract class IntAVLTree {
+abstract class IntAVLTree implements Serializable {
 
     /**
      * We use <tt>0</tt> instead of <tt>-1</tt> so that left(NIL) works without
@@ -507,7 +508,7 @@ abstract class IntAVLTree {
     /**
      * A stack of int values.
      */
-    private static class IntStack {
+    private static class IntStack implements Serializable {
 
         private int[] stack;
         private int size;
@@ -535,7 +536,7 @@ abstract class IntAVLTree {
 
     }
 
-    private static class NodeAllocator {
+    private static class NodeAllocator implements Serializable {
 
         private int nextNode;
         private final IntStack releasedNodes;

--- a/src/main/java/com/tdunning/math/stats/TDigest.java
+++ b/src/main/java/com/tdunning/math/stats/TDigest.java
@@ -17,6 +17,7 @@
 
 package com.tdunning.math.stats;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 
@@ -39,7 +40,7 @@ import java.util.Collection;
  * <p/>
  * g) easy to adapt for use with map-reduce
  */
-public abstract class TDigest {
+public abstract class TDigest implements Serializable {
     /**
      * Creates an ArrayDigest with default page size.
      *

--- a/src/test/java/com/tdunning/math/stats/TDigestSerializationTest.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestSerializationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning.math.stats;
+
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.*;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Verifies that the various TDigest implementations can be serialized.
+ *
+ * Serializability is important, for example, if we want to use t-digests with Spark.
+ */
+public class TDigestSerializationTest {
+
+    @Test
+    public void testTreeDigest() {
+        assertSerializesAndDeserializes(new TreeDigest(100));
+    }
+
+    @Test
+    public void testMergingDigest() {
+        assertSerializesAndDeserializes(new MergingDigest(100));
+    }
+
+    @Test
+    public void testAVLTreeDigest() {
+        assertSerializesAndDeserializes(new AVLTreeDigest(100));
+    }
+
+    @Test
+    public void testArrayDigest() {
+        assertSerializesAndDeserializes(new ArrayDigest(32, 100));
+    }
+
+    protected void assertSerializesAndDeserializes(TDigest tdigest) {
+        assertNotNull(SerializationUtils.deserialize(SerializationUtils.serialize(tdigest)));
+
+        tdigest.add(1);
+        assertNotNull(SerializationUtils.deserialize(SerializationUtils.serialize(tdigest)));
+    }
+}


### PR DESCRIPTION
Spark doesn't have (approx) quantile [yet](https://issues.apache.org/jira/browse/SPARK-6761) so in the meantime I'd like to use t-digest to calculate it.

For that to work, the TDigests need to be serializable (all instances and their object graphs). Please let me know if I missed any cases...

Also, I hope this is actually a proper use of TDigest, and would like to know if there is an impl (TreeDigest, MergingDigest, etc.) that would be most appropriate to use with [RDD](http://spark.apache.org/docs/1.3.1/api/scala/index.html#org.apache.spark.rdd.RDD).aggregate, given the example usage below:

```scala
import com.tdunning.math.stats._

val random = new scala.util.Random()
val n = 1000000

val seq = Seq.fill(n)(random.nextInt(n))
val rdd = sc.parallelize(seq, 100)

val tdigest = rdd.aggregate[TDigest](zeroValue = new TreeDigest(100))(
  seqOp = { (td, value) => td.add(value) ; td },
  combOp = { (td0, td1) => td0.add(td1) ; td0 })

tdigest.quantile(0.999)
// res0: Double = 998973.5852724959
```

Thanks,
Ray