### PR TITLE
Move test from TDigestTest to TreeDigestTest to prevent Travis error.

### DIFF
--- a/src/test/java/com/tdunning/math/stats/TDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestTest.java
@@ -387,16 +387,6 @@ public class TDigestTest {
         }
     }
 
-    @Test
-    public void testMergeEmpty() {
-        final Random gen0 = RandomUtils.getRandom();
-        List<TDigest> subData = new ArrayList<TDigest>();
-        subData.add(new TreeDigest(10));
-        TreeDigest foo = new TreeDigest(10);
-        AbstractTDigest.merge(subData, gen0, foo);
-        empty(foo);
-    }
-
     public static class DigestFactory<T extends TDigest> {
         public T create() {
             throw new UnsupportedOperationException("Must over-ride");

--- a/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TreeDigestTest.java
@@ -449,6 +449,16 @@ public class TreeDigestTest extends TDigestTest {
     }
 
     @Test
+    public void testMergeEmpty() {
+        final Random gen0 = RandomUtils.getRandom();
+        List<TDigest> subData = new ArrayList<TDigest>();
+        subData.add(new TreeDigest(10));
+        TreeDigest foo = new TreeDigest(10);
+        AbstractTDigest.merge(subData, gen0, foo);
+        empty(foo);
+    }
+
+    @Test
     public void testSingleValue() {
         singleValue(new TreeDigest(100));
     }


### PR DESCRIPTION
When submitting PR #56 Travis complained on the [OpenJDK build](https://travis-ci.org/tdunning/t-digest/jobs/65023244#L1450) but not the [Oracle JDK build](https://travis-ci.org/tdunning/t-digest/jobs/65023243):

```
Running com.tdunning.math.stats.TDigestTest
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.032 sec <<< FAILURE! - in com.tdunning.math.stats.TDigestTest
testMergeEmpty(com.tdunning.math.stats.TDigestTest)  Time elapsed: 0.032 sec  <<< ERROR!
java.lang.NullPointerException: null
	at com.tdunning.math.stats.TDigestTest.flush(TDigestTest.java:75)
```

For some reason with OpenJDK Travis sees the `testMergeEmpty` test in `TDigestTest`, and runs it. `TDigestTest` is not initialized (via [`setup`](https://github.com/tdunning/t-digest/blob/master/src/test/java/com/tdunning/math/stats/TDigestTest.java#L62)) like the [other subclasses are](https://github.com/tdunning/t-digest/blob/master/src/test/java/com/tdunning/math/stats/TreeDigestTest.java#L40) so the call to `flush` fails as shown above.

I think the test should be moved, if not only to make the Travis build work with OpenJDK, but also to keep `TDigestTest` clear of tests.

Thanks,
Ray
