### PR TITLE
Make Centroid id transient & init in readObject

### DIFF
--- a/src/main/java/com/tdunning/math/stats/Centroid.java
+++ b/src/main/java/com/tdunning/math/stats/Centroid.java
@@ -17,6 +17,8 @@
 
 package com.tdunning.math.stats;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +32,10 @@ public class Centroid implements Comparable<Centroid>, Serializable {
 
     private double centroid = 0;
     private int count = 0;
-    private int id;
+
+    // The ID is transient because it must be unique within a given JVM. A new
+    // ID should be generated from uniqueCount when a Centroid is deserialized.
+    private transient int id;
 
     private List<Double> actualData = null;
 
@@ -142,5 +147,10 @@ public class Centroid implements Comparable<Centroid>, Serializable {
         }
         centroid = AbstractTDigest.weightedAverage(centroid, count, x, w);
         count += w;
+    }
+
+    private void readObject(ObjectInputStream in) throws ClassNotFoundException, IOException {
+        in.defaultReadObject();
+        id = uniqueCount.getAndIncrement();
     }
 }


### PR DESCRIPTION
@tdunning I believe this will fix the issue that I was hitting a while back. It should ensure that every time a Centroid is serialized its `id` is omitted, and when it's later deserialized (possibly in a different JVM) it gets a new `id` (which will be unique to that JVM). Does that make sense?