### PR TITLE
Stop overflow of aggregatedCounts when storing 4B+ values

### DIFF
--- a/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
+++ b/src/main/java/com/tdunning/math/stats/AVLGroupTree.java
@@ -37,7 +37,7 @@ final class AVLGroupTree extends AbstractCollection<Centroid> implements Seriali
     private double[] centroids;
     private int[] counts;
     private List<Double>[] datas;
-    private int[] aggregatedCounts;
+    private long[] aggregatedCounts;
     private final IntAVLTree tree;
 
     AVLGroupTree() {
@@ -99,7 +99,7 @@ final class AVLGroupTree extends AbstractCollection<Centroid> implements Seriali
         };
         centroids = new double[tree.capacity()];
         counts = new int[tree.capacity()];
-        aggregatedCounts = new int[tree.capacity()];
+        aggregatedCounts = new long[tree.capacity()];
         if (record) {
             @SuppressWarnings("unchecked")
             final List<Double>[] datas = new List[tree.capacity()];
@@ -110,6 +110,7 @@ final class AVLGroupTree extends AbstractCollection<Centroid> implements Seriali
     /**
      * Return the number of centroids in the tree.
      */
+    @Override
     public int size() {
         return tree.size();
     }
@@ -274,7 +275,7 @@ final class AVLGroupTree extends AbstractCollection<Centroid> implements Seriali
     /**
      * Return the total count of points that have been added to the tree.
      */
-    public int sum() {
+    public long sum() {
         return aggregatedCounts[tree.root()];
     }
 

--- a/src/test/java/com/tdunning/math/stats/TDigestTest.java
+++ b/src/test/java/com/tdunning/math/stats/TDigestTest.java
@@ -429,6 +429,36 @@ public abstract class TDigestTest extends AbstractTest {
         for (double q : quantiles) {
             final double v = digest.quantile(q);
             assertTrue(v >= prev);
+            assertTrue("Unexpectedly low value: " + v, v >= 0.0);
+            assertTrue("Unexpectedly high value: " + v, v <= 1.0);
+            prev = v;
+        }
+    }
+
+    @Test
+    public void testMoreThan4BValues() {
+        final TDigest digest = factory().create();
+        Random gen = getRandom();
+        for (int i = 0; i < 1000; ++i) {
+            final double next = gen.nextDouble();
+            digest.add(next);
+        }
+        for (int i = 0; i < 10; ++i) {
+            final double next = gen.nextDouble();
+            final int count = 1 << 29;
+            digest.add(next, count);
+        }
+        assertEquals(1000 + 10L * (1 << 29), digest.size());
+        assertTrue(digest.size() > 2 * Integer.MAX_VALUE);
+        final double[] quantiles = new double[] { 0, 0.1, 0.5, 0.9, 1, gen.nextDouble() };
+        Arrays.sort(quantiles);
+        double prev = Double.NEGATIVE_INFINITY;
+        for (double q : quantiles) {
+            final double v = digest.quantile(q);
+            System.out.println("q=" + q + ", v=" + v);
+            assertTrue(v >= prev);
+            assertTrue("Unexpectedly low value: " + v, v >= 0.0);
+            assertTrue("Unexpectedly high value: " + v, v <= 1.0);
             prev = v;
         }
     }


### PR DESCRIPTION
Previous to this change aggregatedCounts could overflow if more than
`2 * Integer.MAX_VALUE` values were added to the tree. this is because
the aggregatedCounts stored in the tree which contains, for each node,
the sum of the count for the node and its children was stored as an int[].
When more than `2 * Integer.MAX_VALUE` values are stored in the tree the
counts of especially the nodes which are the direct children of the root
node can overflow and cause strange result when quantiles for that node
or to the right of that node are requested.

Technically the root node's aggregated count will overflow when more
than `1 * Integer.MAX_VALUE` values are inserted but this has no effect
on the results since the aggregatedCount for the root node is never used.

The solution is to store the aggregatedCounts as a long[] which will
increase the memory usage per centroid to increase from 29 bytes (13
bytes from IntAVLTree and 16 bytes from AVLGroupTree) to 33 bytes so
will increase the memory usage by ~12%.
