### PR TITLE
add OSGi related information to the MANIFEST.MF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,40 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <bnd>
+<![CDATA[
+Import-Package: \
+  *
+-exportcontents: \
+  !*.internal.*,\
+  !*.impl.*,\
+  com.tdunning.*
+]]>
+                    </bnd>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>


### PR DESCRIPTION
This allows the artifact to be used in OSGi containers without any modifications as it contains the related information now already.
