### PR TITLE
put fromBytes in TDigest contract.

### DIFF
--- a/core/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
+++ b/core/src/main/java/com/tdunning/math/stats/AVLTreeDigest.java
@@ -373,6 +373,11 @@ public class AVLTreeDigest extends AbstractTDigest {
         }
     }
 
+    @Override
+    public TDigest getFromBytes(ByteBuffer buf) {
+        return AVLTreeDigest.fromBytes(buf);
+    }
+
     /**
      * Reads a histogram from a byte buffer
      *

--- a/core/src/main/java/com/tdunning/math/stats/MergingDigest.java
+++ b/core/src/main/java/com/tdunning/math/stats/MergingDigest.java
@@ -805,6 +805,11 @@ public class MergingDigest extends AbstractTDigest {
         }
     }
 
+    @Override
+    public TDigest getFromBytes(ByteBuffer buf) {
+        return MergingDigest.fromBytes(buf);
+    }
+
     @SuppressWarnings("WeakerAccess")
     public static MergingDigest fromBytes(ByteBuffer buf) {
         int encoding = buf.getInt();

--- a/core/src/main/java/com/tdunning/math/stats/TDigest.java
+++ b/core/src/main/java/com/tdunning/math/stats/TDigest.java
@@ -185,6 +185,14 @@ public abstract class TDigest implements Serializable {
     public abstract void asSmallBytes(ByteBuffer buf);
 
     /**
+     * Deserializes the TDigest object from given byte buffer.
+     * @param buf The byte buffer into which the TDigest should be deserialized.
+     * @return A new TDigest object deserialized from byte buffer. Note that
+     * <ITALIC>this</ITALIC> TDigest remains intact
+     */
+    public abstract TDigest getFromBytes(ByteBuffer buf);
+
+    /**
      * Tell this TDigest to record the original data as much as possible for test
      * purposes.
      *


### PR DESCRIPTION

A general scenario where this might be useful: 
`TDigest#createDiges`t returns an abstract TDigest which is used to get the recommended implementation of TDigest. We can serialize it using `asBytes` and `asSmallBytes`, but deserializing required to know the implementation because fromBytes is not mentioned in the TDigest contract