### PR TITLE
Refactoring out serialization related duties and capturing essence of digest as DigestModel

### DIFF
--- a/core/src/main/java/com/tdunning/math/stats/AbstractTDigest.java
+++ b/core/src/main/java/com/tdunning/math/stats/AbstractTDigest.java
@@ -57,35 +57,6 @@ public abstract class AbstractTDigest extends TDigest {
         return (x - x0) / (x1 - x0);
     }
 
-    static void encode(ByteBuffer buf, int n) {
-        int k = 0;
-        while (n < 0 || n > 0x7f) {
-            byte b = (byte) (0x80 | (0x7f & n));
-            buf.put(b);
-            n = n >>> 7;
-            k++;
-            if (k >= 6) {
-                throw new IllegalStateException("Size is implausibly large");
-            }
-        }
-        buf.put((byte) n);
-    }
-
-    static int decode(ByteBuffer buf) {
-        int v = buf.get();
-        int z = 0x7f & v;
-        int shift = 7;
-        while ((v & 0x80) != 0) {
-            if (shift > 28) {
-                throw new IllegalStateException("Shift too large in decode");
-            }
-            v = buf.get();
-            z += (v & 0x7f) << shift;
-            shift += 7;
-        }
-        return z;
-    }
-
     abstract void add(double x, int w, Centroid base);
 
     /**

--- a/core/src/main/java/com/tdunning/math/stats/DigestModel.java
+++ b/core/src/main/java/com/tdunning/math/stats/DigestModel.java
@@ -1,0 +1,71 @@
+package com.tdunning.math.stats;
+
+public class DigestModel {
+  private final double compression;
+  private final double min;
+  private final double max;
+  private final int centroidCount;
+  private final double[] centroidPositions;
+  private final double[] centroidWeights;
+
+  //For compact encoding of MergingDigest
+  private Integer mainBufferSize = null;
+  private Integer tempBufferSize = null;
+
+  private boolean compactEncoding = false;
+
+  public DigestModel(double compression, double min, double max, int centroidCount, double[] centroidPositions, double[] centroidWeights) {
+    this.compression = compression;
+    this.min = min;
+    this.max = max;
+    this.centroidCount = centroidCount;
+    this.centroidPositions = centroidPositions;
+    this.centroidWeights = centroidWeights;
+  }
+
+  public DigestModel(double compression, double min, double max, int centroidCount, double[] centroidPositions, double[] centroidWeights, int mainBufferSize, int tempBufferSize) {
+    this(compression, min, max, centroidCount, centroidPositions, centroidWeights);
+    this.mainBufferSize = mainBufferSize;
+    this.tempBufferSize = tempBufferSize;
+  }
+
+  public void setCompactEncoding(boolean compactEncoding) {
+    this.compactEncoding = compactEncoding;
+  }
+
+  public double compression() {
+    return compression;
+  }
+
+  public double min() {
+    return min;
+  }
+
+  public double max() {
+    return max;
+  }
+
+  public int centroidCount() {
+    return centroidCount;
+  }
+
+  public double[] centroidPositions() {
+    return centroidPositions;
+  }
+
+  public double[] centroidWeights() {
+    return centroidWeights;
+  }
+
+  public boolean compactEncoding() {
+    return compactEncoding;
+  }
+
+  public Integer mainBufferSize() {
+    return mainBufferSize;
+  }
+
+  public Integer tempBufferSize() {
+    return tempBufferSize;
+  }
+}

--- a/core/src/main/java/com/tdunning/math/stats/TDigest.java
+++ b/core/src/main/java/com/tdunning/math/stats/TDigest.java
@@ -185,6 +185,13 @@ public abstract class TDigest implements Serializable {
     public abstract void asSmallBytes(ByteBuffer buf);
 
     /**
+     * Returns final representation of the digest as a plain data structure
+     * Can be used for serde, inter-conversion, etc
+     * @return DigestModel which captures minimum required fields for representing the digest accurately
+     */
+    public abstract DigestModel toModel();
+
+    /**
      * Tell this TDigest to record the original data as much as possible for test
      * purposes.
      *

--- a/core/src/main/java/com/tdunning/math/stats/serde/AVLTreeDigestCompactSerde.java
+++ b/core/src/main/java/com/tdunning/math/stats/serde/AVLTreeDigestCompactSerde.java
@@ -1,0 +1,91 @@
+package com.tdunning.math.stats.serde;
+
+import com.tdunning.math.stats.AVLTreeDigest;
+import com.tdunning.math.stats.DigestModel;
+
+import java.nio.ByteBuffer;
+
+public class AVLTreeDigestCompactSerde {
+
+  public static int byteSize(AVLTreeDigest digest) {
+    DigestModel model = digest.toModel();
+    int bound = DigestModelDefaultSerde.byteSize(model.centroidCount());
+    ByteBuffer buf = ByteBuffer.allocate(bound);
+    serialize(digest, buf);
+    return buf.position();
+  }
+
+  public static void serialize(AVLTreeDigest digest, ByteBuffer buf) {
+    DigestModel model = digest.toModel();
+    buf.putInt(Encoding.COMPACT.code());
+    buf.putDouble(model.min());
+    buf.putDouble(model.max());
+    buf.putDouble(model.compression());
+    buf.putInt(model.centroidCount());
+
+    double[] position = model.centroidPositions();
+    double[] weight = model.centroidWeights();
+    double x = 0;
+    for(int i = 0;i < model.centroidCount(); i++) {
+      double delta = position[i] - x;
+      x = position[i];
+      buf.putFloat((float) delta);
+      encodeInt(buf, (int) weight[i]);
+    }
+  }
+
+  public static AVLTreeDigest deserialize(ByteBuffer buf) {
+    boolean compactEncoding = buf.getInt() == Encoding.COMPACT.code();
+    if (!compactEncoding) {
+      throw new IllegalArgumentException("Serialization was not done using compact encoding, cannot deserialize");
+    }
+
+    double min = buf.getDouble();
+    double max = buf.getDouble();
+    double compression = buf.getDouble();
+    int centroidCount = buf.getInt();
+
+    double[] position = new double[centroidCount];
+    double[] weight = new double[centroidCount];
+    double x = 0;
+    for (int i = 0; i < centroidCount; i++) {
+      double delta = buf.getFloat();
+      x += delta;
+      position[i] = x;
+      weight[i] = decodeInt(buf);
+    }
+
+    DigestModel model = new DigestModel(compression, min, max, centroidCount, position, weight);
+    model.setCompactEncoding(true);
+    return AVLTreeDigest.fromModel(model);
+  }
+
+  public static void encodeInt(ByteBuffer buf, int n) {
+      int k = 0;
+      while (n < 0 || n > 0x7f) {
+          byte b = (byte) (0x80 | (0x7f & n));
+          buf.put(b);
+          n = n >>> 7;
+          k++;
+          if (k >= 6) {
+              throw new IllegalStateException("Size is implausibly large");
+          }
+      }
+      buf.put((byte) n);
+  }
+
+  public static int decodeInt(ByteBuffer buf) {
+      int v = buf.get();
+      int z = 0x7f & v;
+      int shift = 7;
+      while ((v & 0x80) != 0) {
+          if (shift > 28) {
+              throw new IllegalStateException("Shift too large in decode");
+          }
+          v = buf.get();
+          z += (v & 0x7f) << shift;
+          shift += 7;
+      }
+      return z;
+  }
+}

--- a/core/src/main/java/com/tdunning/math/stats/serde/DigestModelDefaultSerde.java
+++ b/core/src/main/java/com/tdunning/math/stats/serde/DigestModelDefaultSerde.java
@@ -1,0 +1,47 @@
+package com.tdunning.math.stats.serde;
+
+import com.tdunning.math.stats.DigestModel;
+
+import java.nio.ByteBuffer;
+
+public class DigestModelDefaultSerde {
+
+  public static int byteSize(int centroids) {
+    return (centroids * 16) + 32;
+  }
+
+  public static void serialize(DigestModel model, ByteBuffer buf) {
+    buf.putInt(Encoding.VERBOSE.code());
+    buf.putDouble(model.min());
+    buf.putDouble(model.max());
+    buf.putDouble(model.compression());
+    buf.putInt(model.centroidCount());
+    double[] position = model.centroidPositions();
+    double[] weight = model.centroidWeights();
+    for (int i = 0; i < model.centroidCount(); i++) {
+      buf.putDouble(position[i]);
+      buf.putDouble(weight[i]);
+    }
+  }
+
+  public static DigestModel deserialize(ByteBuffer buf) {
+    boolean verboseEncoding = buf.getInt() == Encoding.VERBOSE.code();
+    if (!verboseEncoding) {
+      throw new IllegalArgumentException("Serialization was not done using verbose encoding, cannot deserialize");
+    }
+
+    double min = buf.getDouble();
+    double max = buf.getDouble();
+    double compression = buf.getDouble();
+    int centroidCount = buf.getInt();
+    double[] position = new double[centroidCount];
+    double[] weight = new double[centroidCount];
+    for (int i = 0; i < centroidCount; i++) {
+      position[i] = buf.getDouble();
+      weight[i] = buf.getDouble();
+    }
+
+    return new DigestModel(compression, min, max, centroidCount, position, weight);
+  }
+
+}

--- a/core/src/main/java/com/tdunning/math/stats/serde/Encoding.java
+++ b/core/src/main/java/com/tdunning/math/stats/serde/Encoding.java
@@ -1,0 +1,15 @@
+package com.tdunning.math.stats.serde;
+
+public enum Encoding {
+  VERBOSE(1), COMPACT(2);
+
+  private final int code;
+
+  Encoding(int code) {
+    this.code = code;
+  }
+
+  public int code() {
+    return this.code;
+  }
+}

--- a/core/src/main/java/com/tdunning/math/stats/serde/MergingDigestCompactSerde.java
+++ b/core/src/main/java/com/tdunning/math/stats/serde/MergingDigestCompactSerde.java
@@ -1,0 +1,58 @@
+package com.tdunning.math.stats.serde;
+
+import com.tdunning.math.stats.DigestModel;
+import com.tdunning.math.stats.MergingDigest;
+
+import java.nio.ByteBuffer;
+
+
+public class MergingDigestCompactSerde {
+
+  public static int byteSize(int centroids) {
+    return (centroids * 8) + 30;
+  }
+
+  public static void serialize(MergingDigest digest, ByteBuffer buf) {
+    DigestModel model = digest.toModel();
+    buf.putInt(Encoding.COMPACT.code());
+    buf.putDouble(model.min());                          // + 8
+    buf.putDouble(model.max());                          // + 8
+    buf.putFloat((float) model.compression());           // + 4
+    buf.putShort((short) model.mainBufferSize().intValue());           // + 2
+    buf.putShort((short) model.tempBufferSize().intValue());       // + 2
+    buf.putShort((short) model.centroidCount());          // + 2 = 30
+
+    double[] position = model.centroidPositions();
+    double[] weight = model.centroidWeights();
+    for (int i = 0; i < model.centroidCount(); i++) {
+      buf.putFloat((float) position[i]);
+      buf.putFloat((float) weight[i]);
+    }
+  }
+
+  public static MergingDigest deserialize(ByteBuffer buf) {
+    boolean compactEncoding = buf.getInt() == Encoding.COMPACT.code();
+    if (!compactEncoding) {
+      throw new IllegalArgumentException("Serialization was not done using compact encoding, cannot deserialize");
+    }
+
+    double min = buf.getDouble();
+    double max = buf.getDouble();
+    double compression = buf.getFloat();
+    int mainBufferSize = buf.getShort();
+    int tempBufferSize = buf.getShort();
+    int centroidCount = buf.getShort();
+
+    double[] position = new double[centroidCount];
+    double[] weight = new double[centroidCount];
+    for (int i = 0; i < centroidCount; i++) {
+      position[i] = buf.getFloat();
+      weight[i] = buf.getFloat();
+    }
+
+    DigestModel model = new DigestModel(compression, min, max, centroidCount, position, weight, mainBufferSize, tempBufferSize);
+    model.setCompactEncoding(true);
+    return MergingDigest.fromModel(model);
+  }
+
+}

--- a/core/src/test/java/com/tdunning/math/stats/TDigestTest.java
+++ b/core/src/test/java/com/tdunning/math/stats/TDigestTest.java
@@ -20,6 +20,7 @@ package com.tdunning.math.stats;
 import com.clearspring.analytics.stream.quantile.QDigest;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.tdunning.math.stats.serde.AVLTreeDigestCompactSerde;
 import org.apache.mahout.common.RandomUtils;
 import org.apache.mahout.math.jet.random.AbstractContinousDistribution;
 import org.apache.mahout.math.jet.random.Gamma;
@@ -732,13 +733,13 @@ public abstract class TDigestTest extends AbstractTest {
             int n = gen.nextInt();
             n = n >>> (i / 100);
             ref.add(n);
-            AbstractTDigest.encode(buf, n);
+            AVLTreeDigestCompactSerde.encodeInt(buf, n);
         }
 
         buf.flip();
 
         for (int i = 0; i < 3000; i++) {
-            int n = AbstractTDigest.decode(buf);
+            int n = AVLTreeDigestCompactSerde.decodeInt(buf);
             assertEquals(String.format("%d:", i), ref.get(i).intValue(), n);
         }
     }

--- a/core/src/test/java/com/tdunning/math/stats/TDigestUtilTest.java
+++ b/core/src/test/java/com/tdunning/math/stats/TDigestUtilTest.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Random;
 
+import com.tdunning.math.stats.serde.AVLTreeDigestCompactSerde;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -36,13 +37,13 @@ public class TDigestUtilTest extends AbstractTest {
             int n = gen.nextInt();
             n = n >>> (i / 100);
             ref.add(n);
-            AbstractTDigest.encode(buf, n);
+            AVLTreeDigestCompactSerde.encodeInt(buf, n);
         }
 
         buf.flip();
 
         for (int i = 0; i < 3000; i++) {
-            int n = AbstractTDigest.decode(buf);
+            int n = AVLTreeDigestCompactSerde.decodeInt(buf);
             assertEquals(String.format("%d:", i), ref.get(i).intValue(), n);
         }
     }


### PR DESCRIPTION
#87 issue discusses about the design changes here. In this PR, did not adhere to a Transcoder interface since small encoding technique differs across digests. Also it does not seem essential since enforcing conversion to-from DigestModel ensures other serialization techniques can be plugged in later.

Backwards compatibility has been maintained.