### PR TITLE
Add benchmark for Sort on ordered input

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.tdunning</groupId>
             <artifactId>t-digest</artifactId>
-            <version>3.2</version>
+            <version>3.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/benchmark/src/main/java/com/tdunning/SortBench.java
+++ b/benchmark/src/main/java/com/tdunning/SortBench.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tdunning;
+
+import com.tdunning.math.stats.Sort;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/** Explores the performance of Sort on pathological input data. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 20, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+@State(Scope.Thread)
+public class SortBench {
+    private final int size = 100000;
+    private final double[] values = new double[size];
+
+    @Param({"0", "1", "-1"})
+    public int sortDirection;
+
+    @Setup
+    public void setup() {
+        Random prng = new Random(999983);
+        for (int i = 0; i < size; i++) {
+            values[i] = prng.nextDouble();
+        }
+        if (sortDirection > 0) {
+            Arrays.sort(values);
+        } else if (sortDirection < 0) {
+            Arrays.sort(values);
+            Sort.reverse(values, 0, values.length);
+        }
+    }
+
+    @Benchmark
+    public void quicksort() {
+        int[] order = new int[size];
+        for (int i = 0; i < size; i++) {
+            order[i] = i;
+        }
+        Sort.sort(order, values);
+    }
+}

--- a/core/src/main/java/com/tdunning/math/stats/Sort.java
+++ b/core/src/main/java/com/tdunning/math/stats/Sort.java
@@ -78,7 +78,7 @@ public class Sort {
         while (end - start > limit) {
 
             // median of three values for the pivot
-            int a = start;
+            int a = start + 1;
             int b = (start + end) / 2;
             int c = end - 1;
 

--- a/core/src/main/java/com/tdunning/math/stats/Sort.java
+++ b/core/src/main/java/com/tdunning/math/stats/Sort.java
@@ -17,10 +17,13 @@
 
 package com.tdunning.math.stats;
 
+import java.util.Random;
+
 /**
  * Static sorting methods
  */
 public class Sort {
+    private static final Random prng = new Random(); // for choosing pivots during quicksort
     /**
      * Quick sort using an index array.  On return,
      * values[order[i]] is in order as i goes 0..values.length
@@ -77,53 +80,9 @@ public class Sort {
         // the while loop implements tail-recursion to avoid excessive stack calls on nasty cases
         while (end - start > limit) {
 
-            // median of three values for the pivot
-            int a = start + 1;
-            int b = (start + end) / 2;
-            int c = end - 1;
-
-            int pivotIndex;
-            double pivotValue;
-            double va = values[order[a]];
-            double vb = values[order[b]];
-            double vc = values[order[c]];
-            //noinspection Duplicates
-            if (va > vb) {
-                if (vc > va) {
-                    // vc > va > vb
-                    pivotIndex = a;
-                    pivotValue = va;
-                } else {
-                    // va > vb, va >= vc
-                    if (vc < vb) {
-                        // va > vb > vc
-                        pivotIndex = b;
-                        pivotValue = vb;
-                    } else {
-                        // va >= vc >= vb
-                        pivotIndex = c;
-                        pivotValue = vc;
-                    }
-                }
-            } else {
-                // vb >= va
-                if (vc > vb) {
-                    // vc > vb >= va
-                    pivotIndex = b;
-                    pivotValue = vb;
-                } else {
-                    // vb >= va, vb >= vc
-                    if (vc < va) {
-                        // vb >= va > vc
-                        pivotIndex = a;
-                        pivotValue = va;
-                    } else {
-                        // vb >= vc >= va
-                        pivotIndex = c;
-                        pivotValue = vc;
-                    }
-                }
-            }
+            // pivot by a random element
+            int pivotIndex = start + prng.nextInt(end - start);
+            double pivotValue = values[order[pivotIndex]];
 
             // move pivot to beginning of array
             swap(order, start, pivotIndex);


### PR DESCRIPTION
`Sort.sort` has O(N^2) performance on reverse-sorted input. This PR adds benchmarks that demonstrate this behavior, and a simple change to fix it.

### no changes
```
SortBench.quicksort                0  avgt   20    12.271 ± 0.040  ms/op
SortBench.quicksort                1  avgt   20    32.556 ± 0.257  ms/op
SortBench.quicksort               -1  avgt   20  1426.844 ± 6.783  ms/op
```

### simple tweak (`int a = start` -> `int a = start + 1`)
```
SortBench.quicksort                0  avgt   20  12.380 ± 0.031  ms/op
SortBench.quicksort                1  avgt   20  31.164 ± 0.151  ms/op
SortBench.quicksort               -1  avgt   20  12.603 ± 0.046  ms/op
```

This change is legal as long as `limit > 0`, since `end - start > 1` implies `start + 1 < end`.

For the sake of completeness, I also benchmarked two additional strategies.

## random element
```
SortBench.quicksort                0  avgt   20  12.251 ± 0.063  ms/op
SortBench.quicksort                1  avgt   20   5.940 ± 0.047  ms/op
SortBench.quicksort               -1  avgt   20   5.859 ± 0.028  ms/op
```

### median of 3 random elements
```
SortBench.quicksort                0  avgt   20  12.810 ± 0.163  ms/op
SortBench.quicksort                1  avgt   20   5.393 ± 0.032  ms/op
SortBench.quicksort               -1  avgt   20   5.572 ± 0.028  ms/op
```