### PR TITLE
[README.md] add reference to ajwerner/tdigestc

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The t-digest algorithm has been ported to other languages:
  - Javascript: [tdigest](https://github.com/welch/tdigest)
  - C++: [CPP TDigest](https://github.com/gpichot/cpp-tdigest), [FB's Folly Implementation (high performance)](https://github.com/facebook/folly/blob/master/folly/stats/QuantileEstimator.h)
  - Scala: need link!
+ - C: [tdigestc (w/ bindings to Go, Java, Python, JS via wasm)](https://githb.com/ajwerner/tdigestc)
 
 Continuous Integration
 =================


### PR DESCRIPTION
Hi Ted,

I'm Andrew and I've been a happy user of the t-digest data structure since I implemented it for a previous employer in 2014. I recently found myself in a break between jobs and decided I wanted to experiment with polyglot library development. As the idea evolved, I decided I wanted to do it with a useful self-contained library that gains value by having bindings to a wide variety of languages. I also really liked your recent work on the MergingDigest as it is much simpler than the previous tree-based digest in AVLTreeDigest and I had implemented in 2014. 

This pull request just adds a link to my https://github.com/ajwerner/tdigestc repo which I intend to sure up a bit more but wanted to get the ball rolling on announcing it a little bit if only so that I have more social pressure to work on it.

The implementation does not yet use the new sin inverse weighting but instead uses the old sqrt approximation. It also needs some more serious testing. Right now it's all pretty anecdotal from playing around in the various languages and trying some obvious things. I saw your comment in https://github.com/tdunning/t-digest/issues/109 about testing, I'll try to nail that down soon.

I know this is just a side thing for you and I greatly appreciate all the work you've done.

Best,
Andrew