### PR TITLE
minor README fixes: links & casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ Implementations in Other Languages
 The t-digest algorithm has been ported to other languages:
  - Python: [tdigest](https://github.com/CamDavidsonPilon/tdigest)
  - Go: [github.com/spenczar/tdigest](https://github.com/spenczar/tdigest) [https://github.com/influxdata/tdigest](https://github.com/influxdata/tdigest)
- - Javascript: [tdigest](https://github.com/welch/tdigest)
+ - JavaScript: [tdigest](https://github.com/welch/tdigest)
  - C++: [CPP TDigest](https://github.com/gpichot/cpp-tdigest), [FB's Folly Implementation (high performance)](https://github.com/facebook/folly/blob/master/folly/stats/TDigest.h)
  - Scala: need link!
- - C: [tdigestc (w/ bindings to Go, Java, Python, JS via wasm)](https://githb.com/ajwerner/tdigestc)
+ - C: [tdigestc (w/ bindings to Go, Java, Python, JS via wasm)](https://github.com/ajwerner/tdigestc)
 
 Continuous Integration
 =================
@@ -231,7 +231,7 @@ travis update
 Installation
 ===============
 
-The t-Digest library Jars are released via [Maven Central Repository] (http://repo1.maven.org/maven2/com/tdunning/).
+The t-Digest library Jars are released via [Maven Central Repository](http://repo1.maven.org/maven2/com/tdunning/).
 The current version is 3.2.
 
  ```xml


### PR DESCRIPTION
Notably, the githb.com -> github.com fix was already made in 2 other PRs, but it wasn't
ever merged.