### PR TITLE
Fix NaN quantiles when merging Lists of MergingDigests.

### DIFF
--- a/core/src/main/java/com/tdunning/math/stats/MergingDigest.java
+++ b/core/src/main/java/com/tdunning/math/stats/MergingDigest.java
@@ -307,7 +307,7 @@ public class MergingDigest extends AbstractTDigest {
         if (others.size() == 0) {
             return;
         }
-        int size = lastUsedCell;
+        int size = 0;
         for (TDigest other : others) {
             other.compress();
             size += other.centroidCount();


### PR DESCRIPTION
At the bottom of method `void add(List<? extends TDigest> others)` the following call is made:

    add(m, w, size, data);

Prior to this change, `size` was too big, by amount `lastUsedCell`. The only elements of `m` and `w` that are set are from `others`' centroids. The `size` is passed along as `count` which becomes `incomingCount` when calling `merge()`. Without this change, there are `lastUsedCell` 0-values in `m` and `w` which results in `NaN` values in the quantiles.