### PR TITLE
make setMinMax public to allow for digest creation by library users

### DIFF
--- a/core/src/main/java/com/tdunning/math/stats/TDigest.java
+++ b/core/src/main/java/com/tdunning/math/stats/TDigest.java
@@ -228,10 +228,10 @@ public abstract class TDigest implements Serializable {
     }
 
     /**
-     * Over-ride the min and max values for testing purposes
+     * Over-ride the min and max values for testing purposes and alternative digest creation
      */
     @SuppressWarnings("SameParameterValue")
-    void setMinMax(double min, double max) {
+    public void setMinMax(double min, double max) {
         this.min = min;
         this.max = max;
     }


### PR DESCRIPTION
I have a use case where I am serializing digests from non-jvm envs and want to be able to create jvm digests from pre-merged list of centroids. the `add(double x, int w);` methods allow for adding centroids but I am unable to set the min/max from out the package.

PR makes the setMinMax to allow external users to manually set these member variables.