### PR TITLE
Update Travis CI URL: travis-ci.org -> travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ The t-digest project makes use of Travis integration with Github for testing whe
 
 You can see the reports at:
 
-    https://travis-ci.org/tdunning/t-digest
+    https://app.travis-ci.com/github/tdunning/t-digest
 
 travis update
 


### PR DESCRIPTION
This commit updates the Travis CI URL.

Due to Travis CI ( https://travis-ci.org/github/tdunning/t-digest ) :

> Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on. 