### PR TITLE
Add an Automatic-Module-Name to play nice with Java modules.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -73,6 +73,17 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.tdunning.math.stats</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
                 <configuration>


### PR DESCRIPTION
This PR changes `MANIFEST.MF` to add the attribute `Automatic-Module-Name` with a suggested name.
This change enables t-digest to be used by modular applications.