### PR TITLE
Close #169 Re-order terms in division to avoid periodic decimal and rounding issues in Centroid#add, fixing out-of-order centroids

### DIFF
--- a/core/src/main/java/com/tdunning/math/stats/Centroid.java
+++ b/core/src/main/java/com/tdunning/math/stats/Centroid.java
@@ -81,7 +81,15 @@ public class Centroid implements Comparable<Centroid>, Serializable {
             actualData.add(x);
         }
         count += w;
-        centroid += w * (x - centroid) / count;
+        // NOTE: The previous calculation was computed with `w * (x - centroid) / count;`.
+        //       Now we calculate a factor here for cases where `count` might be a
+        //       number like 3 that could lead to a repeating decimal and possible
+        //       rounding issues. e.g. `count` starts as `0` (zero) and `w` as `3`.
+        //       That could cause a calculation like `3 * (0.8046947099707735 - 0.0) / 3`.
+        //       Calculating this we would get `0.8046947099707736` (same error for `w`
+        //       equals to `6`, `11`, etc.)
+        double factor = (double) w / count;
+        centroid += factor * (x - centroid);
     }
 
     public double mean() {

--- a/core/src/test/java/com/tdunning/math/stats/TDigestTest.java
+++ b/core/src/test/java/com/tdunning/math/stats/TDigestTest.java
@@ -548,6 +548,15 @@ public abstract class TDigestTest extends AbstractTest {
         }
     }
 
+    /**
+     * Issue: https://github.com/tdunning/t-digest/issues/169
+     */
+    public void testCentroidAdd() {
+        double x = 0.8046947099707735;
+        Centroid centroid = new Centroid(x, 3);
+        assertEquals(x, centroid.mean(), 0.0);
+    }
+
     @Test
     public void testNaN() {
         final TDigest digest = factory().create();


### PR DESCRIPTION
Closes #169 

Hi @tdunning :wave: 

I thought this issue was interesting and would allow me to understand more about the t-digest. Tweaking the values used in the tests, I found that changing the compression to `5` (in the `factory()` method) and using this would always reproduce the bug.

```java
    public void testSorted2() {
        final TDigest digest = factory().create();
        ((AVLTreeDigest)digest).gen.setSeed(84);
        int[] weights = new int[] { 7 };
        double[] xs = new double[] {
                0.8046947099707735 };
        assertEquals(weights.length, xs.length);
        for (int i = 0; i < weights.length; ++i) {
            int w = weights[i];
            double x = xs[i];
            for (int j = 0; j < w; j++) {
                digest.add(x);
            }
        }
        Centroid previous = null;
        for (Centroid centroid : digest.centroids()) {
            if (previous != null) {
                assertTrue(previous.mean() <= centroid.mean());
            }
            previous = centroid;
        }
        System.out.println("OK!");
    }
```

Debugging a little more, I realized the issue was happening when the `count[]` array was updated, and the value of a centroid became `3`.

![Screenshot from 2023-05-08 01-32-49](https://user-images.githubusercontent.com/304786/236845414-cb95bda5-ffb0-4195-8342-5a0e265d7b08.png)

A little more debugging and I think I found what was happening. Apparently the `Centroid#add` method could end up having to calculate this `centroid += w * (x - centroid) / count;`, which would not always return the expected value (see the third/sixth/eleventh lines)

```
1 * (0.8046947099707735 - 0.0) / 1 = 0.8046947099707735
2 * (0.8046947099707735 - 0.0) / 2 = 0.8046947099707735
3 * (0.8046947099707735 - 0.0) / 3 = 0.8046947099707736
4 * (0.8046947099707735 - 0.0) / 4 = 0.8046947099707735
5 * (0.8046947099707735 - 0.0) / 5 = 0.8046947099707735
6 * (0.8046947099707735 - 0.0) / 6 = 0.8046947099707736
7 * (0.8046947099707735 - 0.0) / 7 = 0.8046947099707735
8 * (0.8046947099707735 - 0.0) / 8 = 0.8046947099707735
9 * (0.8046947099707735 - 0.0) / 9 = 0.8046947099707735
10 * (0.8046947099707735 - 0.0) / 10 = 0.8046947099707735
11 * (0.8046947099707735 - 0.0) / 11 = 0.8046947099707734
```

I believe it's due to multiplying by `3` to then divide by `3` not being computed in a stable way. I shuffled the terms in the expression, hopefully without changing what it was doing, and I think at least that error should now be fixed? I also tried to add a simple test to reproduce it.

Fixing this should produce centroids with the correct values and order, thus fixing #169 

Cheers

Bruno
