### PR TITLE
Added link to Redis Stack implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ The t-digest algorithm has been ported to other languages:
  - C#: [t-digest-csharp (.NET Core)](https://github.com/Cyral/t-digest-csharp)
  - Kotlin multiplatform: [tdigest_kotlin_multiplatform](https://github.com/beyondeye/tdigest_kotlin_multiplatform)
  - OCaml: [tdigest](https://github.com/SGrondin/tdigest). Purely functional, can also compile to JS via js_of_ocaml.
- 
+ - Redis: [Redis Stack](https://redis.io/docs/data-types/probabilistic/t-digest/) supports t-digest.
+   
 Continuous Integration
 =================
 


### PR DESCRIPTION
Added a link to resources for the Redis Stack implementation of t-digest: https://redis.io/docs/data-types/probabilistic/t-digest/